### PR TITLE
security(fix): resolve 3 CodeQL high-severity findings

### DIFF
--- a/src/core/validation/FilenameValidator.ts
+++ b/src/core/validation/FilenameValidator.ts
@@ -102,8 +102,8 @@ export const FilenameValidator = {
     }
 
     let sanitized = filename
-      // Remove forbidden characters
-      .replace(FORBIDDEN_FILENAME_CHARS, replacement)
+      // Remove forbidden characters (global replacement)
+      .replace(/[<>:"/\\|?*\x00-\x1f]/g, replacement)
       // Remove path traversal
       .replace(/\.\./g, replacement)
       // Trim dots and spaces from ends
@@ -160,8 +160,8 @@ export const FilenameValidator = {
 
     // Basic MIME type format: type/subtype with optional parameters
     // e.g., "text/plain", "application/json", "text/html; charset=utf-8"
-    // eslint-disable-next-line security/detect-unsafe-regex -- Regex is safe: no nested quantifiers, limited character classes, bounded by ^ and $
-    if (!/^[a-z]+\/[a-z0-9.+-]+(?:;\s*[a-z0-9-]+=\S+)*$/i.test(mimeType)) {
+    // eslint-disable-next-line security/detect-unsafe-regex -- Safe: [^\s;]+ cannot backtrack with outer group since ; is excluded
+    if (!/^[a-z]+\/[a-z0-9.+-]+(?:;\s*[a-z0-9-]+=[^\s;]+)*$/i.test(mimeType)) {
       return Result.err(
         ValidationError.invalidFormat('mimeType', mimeType, 'type/subtype (e.g., text/plain)')
       );

--- a/src/request/RequestValidation.ts
+++ b/src/request/RequestValidation.ts
@@ -149,8 +149,9 @@ export function validateUrl(
     }
   }
 
-  // Block javascript: and data: URLs (defense in depth)
-  if (parsed.protocol === 'javascript:' || parsed.protocol === 'data:') {
+  // Block dangerous protocols (defense in depth)
+  const dangerousProtocols = ['javascript:', 'data:', 'vbscript:'];
+  if (dangerousProtocols.includes(parsed.protocol.toLowerCase())) {
     throw RequestError.invalidUrl(url, 'dangerous protocol');
   }
 

--- a/tests/core/validation/Validator.test.ts
+++ b/tests/core/validation/Validator.test.ts
@@ -279,8 +279,7 @@ describe('Validator', () => {
     });
 
     it('should replace forbidden characters', () => {
-      // Note: regex without g flag only replaces first match
-      expect(Validator.sanitizeFilename('file<name>.txt')).toBe('file_name>.txt');
+      expect(Validator.sanitizeFilename('file<name>.txt')).toBe('file_name_.txt');
     });
 
     it('should replace path traversal', () => {
@@ -313,8 +312,7 @@ describe('Validator', () => {
     });
 
     it('should use custom replacement character', () => {
-      // Note: regex without g flag only replaces first match
-      expect(Validator.sanitizeFilename('file<name>.txt', '-')).toBe('file-name>.txt');
+      expect(Validator.sanitizeFilename('file<name>.txt', '-')).toBe('file-name-.txt');
     });
 
     it('should return download if sanitization results in empty', () => {


### PR DESCRIPTION
## Summary

- Fix ReDoS vulnerability in MIME type regex (`\S+` → `[^\s;]+`)
- Fix incomplete string sanitization (add global flag to forbidden char replacement)
- Fix incomplete URL scheme check (case-insensitive protocol comparison)

Closes #2

## Test plan

- [x] All 3958 existing tests pass
- [x] 2 tests updated for new global replacement behavior
- [x] ESLint clean (0 warnings)
- [x] TypeScript strict mode clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)