### PR TITLE
chore(ci): improve Dependabot config and auto-label security PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
     groups:
       dev-dependencies:
         dependency-type: "development"
@@ -21,3 +23,11 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-security-label.yml
+++ b/.github/workflows/dependabot-security-label.yml
@@ -1,0 +1,27 @@
+name: Dependabot Security Label
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add security label
+        if: steps.metadata.outputs.ghsa-id != ''
+        run: gh pr edit "$PR_URL" --add-label "security"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add auto-labels for Dependabot PRs (`dependencies` for npm, `dependencies` + `github_actions` for Actions)
- Group GitHub Actions minor/patch updates to reduce PR noise and CI minutes
- Add workflow to auto-label Dependabot security update PRs with `security` label via GHSA-ID detection

## Test plan
- [ ] CI passes
- [ ] Next Dependabot PR gets auto-labeled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)