### PR TITLE
chore(ci): add manual publish workflow for failed releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v1.0.3)'
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm run build
+
+      - name: Publish to npm
+        run: pnpm publish --access public --no-git-checks --provenance
+
+      - name: Generate SBOM
+        run: pnpm run sbom
+
+      - name: Upload SBOM to release
+        run: gh release upload ${{ inputs.tag }} sbom.cdx.json --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` triggered workflow to manually publish a tagged release to npm
- Includes provenance, SBOM generation, and SBOM upload to GitHub Release
- Safety net for when release-please publish fails (e.g. expired tokens, OIDC misconfiguration)

## Test plan
- [ ] CI passes
- [ ] After merge: trigger with `gh workflow run publish.yml -f tag=v1.0.3` to publish 1.0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)