### PR TITLE
fix(ci): use npm publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Publish to npm
         if: ${{ steps.release.outputs.release_created }}
-        run: pnpm publish --access public --no-git-checks --provenance
+        run: npm publish --access public --provenance
 
       - name: Generate SBOM
         if: ${{ steps.release.outputs.release_created }}
@@ -94,7 +94,7 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        run: pnpm publish --access public --no-git-checks --provenance
+        run: npm publish --access public --provenance
 
       - name: Generate SBOM
         run: pnpm run sbom


### PR DESCRIPTION
## Summary
- Switch from `pnpm publish` to `npm publish` for OIDC trusted publishing compatibility
- pnpm does not support npm's OIDC token exchange natively

## Test plan
- [ ] After merge: `gh workflow run release-please.yml -f tag=v1.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)