### PR TITLE
fix(ci): upgrade npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,10 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: pnpm run build
 
+      - name: Update npm for OIDC trusted publishing
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         if: ${{ steps.release.outputs.release_created }}
         run: npm publish --access public --provenance
@@ -92,6 +96,9 @@ jobs:
 
       - name: Build package
         run: pnpm run build
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Node.js 20 ships with npm 10 which **does not support OIDC token exchange** for trusted publishing (requires npm >= 11.5.1)
- Add `npm install -g npm@latest` before publish steps
- This was the root cause of all E404 errors during publish

References: [npm/cli#8976](https://github.com/npm/cli/issues/8976), [npm/cli#8678](https://github.com/npm/cli/issues/8678)

## Test plan
- [ ] CI passes
- [ ] After merge: `gh workflow run release-please.yml -f tag=v1.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)