### PR TITLE
chore: optimize tsconfig.json for TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     /* Language and Environment */
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
 
@@ -27,14 +27,13 @@
     "allowUnreachableCode": false,
 
     /* Interop Constraints */
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
 
     /* Completeness */
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": []
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Remove redundant `DOM.Iterable` from `lib` (now included in `DOM` in TS6)
- Remove `esModuleInterop` and `allowSyntheticDefaultImports` (always-on in TS6, cannot be disabled)
- Add explicit `types: []` to match TS6 default and prevent unintended `@types/*` auto-discovery

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)