### PR TITLE
security: enable detect-bidi-characters ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,7 @@ export default [
       'prettier/prettier': 'error',
 
       // Security rules
+      'security/detect-bidi-characters': 'error',
       'security/detect-eval-with-expression': 'error',
       'security/detect-unsafe-regex': 'error',
       'security/detect-non-literal-regexp': 'warn',


### PR DESCRIPTION
## Summary

- Enable `security/detect-bidi-characters` rule from eslint-plugin-security 4.0 (PR #46)
- Protects against [Trojan Source](https://trojansource.codes/) attacks (invisible Unicode bidirectional control characters)
- No findings or false positives in current codebase

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)