### PR TITLE
feat(request): expose combineAbortSignals as public utility

### DIFF
--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -13,3 +13,4 @@ export type {
   RequestInterceptorConfig,
   RequestInterceptorInstance,
 } from './RequestInterceptor.js';
+export { combineAbortSignals } from './RequestValidation.js';


### PR DESCRIPTION
## Summary

- Export `combineAbortSignals` from `@zappzarapp/browser-utils/request`
- Function and dedicated tests already exist, only the public export was missing

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)