### PR TITLE
feat(request): add Content-Type response validation

### DIFF
--- a/src/request/RequestInterceptor.ts
+++ b/src/request/RequestInterceptor.ts
@@ -52,7 +52,12 @@ import {
   runErrorMiddleware,
   emitTiming,
 } from './RequestMiddleware.js';
-import { validateUrl, validateCredentialOrigin, combineAbortSignals } from './RequestValidation.js';
+import {
+  validateUrl,
+  validateCredentialOrigin,
+  combineAbortSignals,
+  validateContentType,
+} from './RequestValidation.js';
 
 // =============================================================================
 // Error Types
@@ -71,7 +76,8 @@ export type RequestErrorCode =
   | 'TIMEOUT'
   | 'ABORTED'
   | 'CREDENTIAL_LEAK'
-  | 'SSRF_BLOCKED';
+  | 'SSRF_BLOCKED'
+  | 'CONTENT_TYPE_MISMATCH';
 
 /**
  * Request-specific error.
@@ -132,6 +138,18 @@ export class RequestError extends BrowserUtilsError {
       `Request to private IP address blocked for SSRF protection: ${hostname}`
     );
   }
+
+  static contentTypeMismatch(
+    expected: string | readonly string[],
+    actual: string | null
+  ): RequestError {
+    const expectedStr = Array.isArray(expected) ? expected.join(', ') : String(expected);
+    const actualStr = actual ?? '(none)';
+    return new RequestError(
+      'CONTENT_TYPE_MISMATCH',
+      `Response Content-Type mismatch: expected "${expectedStr}" but received "${actualStr}"`
+    );
+  }
 }
 
 // =============================================================================
@@ -189,6 +207,8 @@ export interface RequestConfig {
   readonly signal?: AbortSignal;
   /** Additional metadata for middleware */
   readonly metadata?: Readonly<Record<string, unknown>>;
+  /** Expected Content-Type for the response (overrides instance default) */
+  readonly expectedContentType?: string | readonly string[];
 }
 
 /**
@@ -209,6 +229,8 @@ export interface MutableRequestConfig {
   signal?: AbortSignal;
   /** Additional metadata for middleware */
   metadata?: Record<string, unknown>;
+  /** Expected Content-Type for the response (overrides instance default) */
+  expectedContentType?: string | readonly string[];
 }
 
 /**
@@ -298,6 +320,18 @@ export interface RequestInterceptorConfig {
    * cannot be detected. This provides defense-in-depth for direct IP access.
    */
   readonly blockPrivateIPs?: boolean;
+  /**
+   * Expected Content-Type for responses (MIME type validation).
+   * Validates that the response Content-Type header matches.
+   * Comparison is case-insensitive on type/subtype; parameters
+   * (e.g., charset) are ignored.
+   *
+   * Can be a single MIME type or an array of accepted types.
+   * Fails closed: missing Content-Type header with this set will throw.
+   *
+   * Default: undefined (no validation).
+   */
+  readonly expectedContentType?: string | readonly string[];
 }
 
 /**
@@ -358,11 +392,12 @@ export interface RequestInterceptorInstance {
 // =============================================================================
 
 const DEFAULT_CONFIG: Required<
-  Omit<RequestInterceptorConfig, 'auth' | 'baseUrl' | 'blockedPatterns'>
+  Omit<RequestInterceptorConfig, 'auth' | 'baseUrl' | 'blockedPatterns' | 'expectedContentType'>
 > & {
   auth: AuthConfig | null;
   baseUrl: string;
   blockedPatterns: readonly RegExp[];
+  expectedContentType: string | readonly string[] | undefined;
 } = {
   baseUrl: '',
   timeout: 30000,
@@ -373,6 +408,7 @@ const DEFAULT_CONFIG: Required<
   blockedPatterns: [],
   validateCredentialOrigin: true,
   blockPrivateIPs: false,
+  expectedContentType: undefined,
 } as const;
 
 /**
@@ -566,6 +602,7 @@ export const RequestInterceptor = {
         timeout: options.timeout,
         signal: init?.signal ?? undefined,
         metadata: {},
+        expectedContentType: options.expectedContentType,
       };
     };
 
@@ -612,6 +649,7 @@ export const RequestInterceptor = {
         timeout: config.timeout,
         signal: config.signal,
         metadata: config.metadata ? Object.freeze({ ...config.metadata }) : undefined,
+        expectedContentType: config.expectedContentType,
       });
     };
 
@@ -666,6 +704,11 @@ export const RequestInterceptor = {
         };
 
         interceptedResponse = await runResponseMiddleware(interceptedResponse, middlewares);
+
+        // Validate Content-Type if expected type is configured
+        if (config.expectedContentType !== undefined) {
+          validateContentType(interceptedResponse.headers, config.expectedContentType);
+        }
 
         emitTiming(
           {
@@ -778,6 +821,7 @@ export const RequestInterceptor = {
           blockedPatterns: Object.freeze([...options.blockedPatterns]),
           validateCredentialOrigin: options.validateCredentialOrigin,
           blockPrivateIPs: options.blockPrivateIPs,
+          expectedContentType: options.expectedContentType,
         });
       },
 

--- a/src/request/RequestValidation.ts
+++ b/src/request/RequestValidation.ts
@@ -219,3 +219,41 @@ export function combineAbortSignals(signal1: AbortSignal, signal2: AbortSignal):
 
   return controller.signal;
 }
+
+/**
+ * Extract base MIME type (type/subtype) from a Content-Type header,
+ * stripping parameters like charset.
+ */
+function parseBaseContentType(contentType: string | null): string | null {
+  if (contentType === null || contentType === '') {
+    return null;
+  }
+  const semicolonIndex = contentType.indexOf(';');
+  const base = semicolonIndex === -1 ? contentType : contentType.substring(0, semicolonIndex);
+  const trimmed = base.trim().toLowerCase();
+  return trimmed === '' ? null : trimmed;
+}
+
+/**
+ * Validate response Content-Type header against expected types.
+ * Fails closed: missing Content-Type with expectedContentType set throws.
+ *
+ * @param responseHeaders - Response headers
+ * @param expectedContentType - Expected MIME type(s)
+ * @throws {RequestError} If Content-Type does not match expected type(s)
+ */
+export function validateContentType(
+  responseHeaders: Headers,
+  expectedContentType: string | readonly string[]
+): void {
+  const rawContentType = responseHeaders.get('content-type');
+  const actualBase = parseBaseContentType(rawContentType);
+
+  const expected = Array.isArray(expectedContentType) ? expectedContentType : [expectedContentType];
+
+  const normalizedExpected = expected.map((t) => t.toLowerCase().trim());
+
+  if (actualBase === null || !normalizedExpected.includes(actualBase)) {
+    throw RequestError.contentTypeMismatch(expectedContentType, rawContentType);
+  }
+}

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -13,4 +13,4 @@ export type {
   RequestInterceptorConfig,
   RequestInterceptorInstance,
 } from './RequestInterceptor.js';
-export { combineAbortSignals } from './RequestValidation.js';
+export { combineAbortSignals, validateContentType } from './RequestValidation.js';

--- a/tests/request/RequestInterceptor.test.ts
+++ b/tests/request/RequestInterceptor.test.ts
@@ -1170,6 +1170,201 @@ describe('RequestInterceptor', () => {
       });
     });
 
+    describe('Content-Type validation', () => {
+      it('should not validate Content-Type by default', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('hello', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+        });
+
+        const response = await api.fetch('/page');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+
+      it('should pass when response Content-Type matches expected type', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('{"ok":true}', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'application/json' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        const response = await api.fetch('/data');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+
+      it('should pass when Content-Type has parameters', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('{"ok":true}', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        const response = await api.fetch('/data');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+
+      it('should throw CONTENT_TYPE_MISMATCH on mismatch', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('<html></html>', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        await expect(api.fetch('/page')).rejects.toThrow('Content-Type mismatch');
+
+        api.destroy();
+      });
+
+      it('should throw when response has no Content-Type (fail closed)', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('data', {
+            status: 200,
+            statusText: 'OK',
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        await expect(api.fetch('/data')).rejects.toThrow('Content-Type mismatch');
+
+        api.destroy();
+      });
+
+      it('should support array of expected types', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('plain text', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/plain' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: ['application/json', 'text/plain'],
+        });
+
+        const response = await api.fetch('/data');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+
+      it('should call error middleware on Content-Type mismatch', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('<html></html>', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        const onError = vi.fn();
+        api.use({ onError });
+
+        await expect(api.fetch('/page')).rejects.toThrow();
+        expect(onError).toHaveBeenCalled();
+
+        api.destroy();
+      });
+
+      it('should allow per-request override via middleware', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('<html></html>', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        api.use({
+          onRequest: (config) => {
+            config.expectedContentType = 'text/html';
+            return config;
+          },
+        });
+
+        const response = await api.fetch('/page');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+
+      it('should allow middleware to clear expectedContentType', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('<html></html>', {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          expectedContentType: 'application/json',
+        });
+
+        api.use({
+          onRequest: (config) => {
+            config.expectedContentType = undefined;
+            return config;
+          },
+        });
+
+        const response = await api.fetch('/page');
+        expect(response.status).toBe(200);
+
+        api.destroy();
+      });
+    });
+
     describe('getConfig', () => {
       it('should return current configuration', () => {
         const api = RequestInterceptor.create({

--- a/tests/request/RequestValidation.test.ts
+++ b/tests/request/RequestValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { combineAbortSignals } from '../../src/request/RequestValidation.js';
+import { combineAbortSignals, validateContentType } from '../../src/request/index.js';
+import { RequestError } from '../../src/request/index.js';
 
 describe('combineAbortSignals', () => {
   it('should abort combined signal when signal1 aborts', () => {
@@ -90,5 +91,65 @@ describe('combineAbortSignals', () => {
     expect(addSpy).not.toHaveBeenCalled();
 
     addSpy.mockRestore();
+  });
+});
+
+describe('validateContentType', () => {
+  it('should pass when Content-Type matches exactly', () => {
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    expect(() => validateContentType(headers, 'application/json')).not.toThrow();
+  });
+
+  it('should pass when Content-Type matches with parameters stripped', () => {
+    const headers = new Headers({ 'Content-Type': 'application/json; charset=utf-8' });
+    expect(() => validateContentType(headers, 'application/json')).not.toThrow();
+  });
+
+  it('should be case-insensitive', () => {
+    const headers = new Headers({ 'Content-Type': 'Application/JSON' });
+    expect(() => validateContentType(headers, 'application/json')).not.toThrow();
+  });
+
+  it('should pass when Content-Type matches one of multiple expected types', () => {
+    const headers = new Headers({ 'Content-Type': 'text/plain' });
+    expect(() => validateContentType(headers, ['application/json', 'text/plain'])).not.toThrow();
+  });
+
+  it('should throw CONTENT_TYPE_MISMATCH on mismatch', () => {
+    const headers = new Headers({ 'Content-Type': 'text/html' });
+    expect(() => validateContentType(headers, 'application/json')).toThrow(RequestError);
+    try {
+      validateContentType(headers, 'application/json');
+    } catch (e) {
+      expect((e as RequestError).code).toBe('CONTENT_TYPE_MISMATCH');
+    }
+  });
+
+  it('should throw when no Content-Type header is present (fail closed)', () => {
+    const headers = new Headers();
+    expect(() => validateContentType(headers, 'application/json')).toThrow(RequestError);
+    try {
+      validateContentType(headers, 'application/json');
+    } catch (e) {
+      expect((e as RequestError).code).toBe('CONTENT_TYPE_MISMATCH');
+      expect((e as RequestError).message).toContain('(none)');
+    }
+  });
+
+  it('should handle whitespace in Content-Type header', () => {
+    const headers = new Headers({ 'Content-Type': '  application/json  ; charset=utf-8' });
+    expect(() => validateContentType(headers, 'application/json')).not.toThrow();
+  });
+
+  it('should throw when Content-Type does not match any in array', () => {
+    const headers = new Headers({ 'Content-Type': 'text/html' });
+    expect(() => validateContentType(headers, ['application/json', 'text/plain'])).toThrow(
+      RequestError
+    );
+  });
+
+  it('should handle case-insensitive expected types', () => {
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    expect(() => validateContentType(headers, 'Application/JSON')).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add built-in MIME type validation for fetch responses (defense-in-depth against MIME confusion attacks)
- Configurable via `expectedContentType` on instance level and per-request override via middleware
- Case-insensitive matching, parameters (charset etc.) stripped automatically
- Fails closed: missing Content-Type header with validation enabled throws `CONTENT_TYPE_MISMATCH`
- 18 new tests (unit + integration)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)