### PR TITLE
chore: replace blanket no-unsafe-* ESLint disables with targeted suppressions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,13 +107,6 @@ export default [
       '@typescript-eslint/prefer-nullish-coalescing': 'warn',
       '@typescript-eslint/prefer-optional-chain': 'warn',
 
-      // Relax unsafe rules for browser DOM APIs
-      '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-argument': 'off',
-      '@typescript-eslint/no-unsafe-call': 'off',
-      '@typescript-eslint/no-unsafe-return': 'off',
-
       // Code quality rules
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prefer-const': 'error',

--- a/src/broadcast/BroadcastManager.ts
+++ b/src/broadcast/BroadcastManager.ts
@@ -207,7 +207,7 @@ export const BroadcastManager = {
 
     // Message handler
     channel.onmessage = (event: MessageEvent): void => {
-      const data = event.data;
+      const data: unknown = event.data;
 
       if (!isValidBroadcastMessage(data)) {
         return;

--- a/src/csp/CspUtils.ts
+++ b/src/csp/CspUtils.ts
@@ -179,9 +179,9 @@ export const CspUtils = {
       document.head.removeChild(script);
 
       // Check if the script executed
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Dynamic window property access for CSP test
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Dynamic window property access for CSP inline-script test
       const result = (window as any)[testKey] === true;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Cleanup test property
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- Cleanup dynamic test property from window
       delete (window as any)[testKey];
 
       cspCache.set('inlineScriptAllowed', result);
@@ -205,6 +205,7 @@ export const CspUtils = {
     try {
       // eslint-disable-next-line @typescript-eslint/no-implied-eval -- Intentionally testing if CSP allows Function constructor
       const fn = new Function('return true');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- Function constructor returns untyped callable; intentional for CSP eval test
       const result = fn() === true;
       cspCache.set('evalAllowed', result);
       return result;

--- a/src/request/RequestValidation.ts
+++ b/src/request/RequestValidation.ts
@@ -249,7 +249,9 @@ export function validateContentType(
   const rawContentType = responseHeaders.get('content-type');
   const actualBase = parseBaseContentType(rawContentType);
 
-  const expected = Array.isArray(expectedContentType) ? expectedContentType : [expectedContentType];
+  const expected: readonly string[] = Array.isArray(expectedContentType)
+    ? expectedContentType
+    : [expectedContentType];
 
   const normalizedExpected = expected.map((t) => t.toLowerCase().trim());
 


### PR DESCRIPTION
## Summary

- Remove 5 blanket `@typescript-eslint/no-unsafe-*` rule disables from `eslint.config.js`
- Fix 6 of 9 violations structurally via better type annotations
- Add 3 targeted per-line suppressions for intentional CSP detection code

### Structural fixes
- `broadcast/BroadcastManager.ts`: type `event.data` as `unknown` (type guard validates)
- `request/RequestValidation.ts`: add `readonly string[]` annotation to prevent `Array.isArray` `any[]` inference

### Targeted suppressions (DOM/CSP interop)
- `csp/CspUtils.ts`: dynamic `window` property access + `Function` constructor call for CSP detection

Closes #3

## Test plan
- [x] ESLint passes with 0 errors/warnings
- [x] TypeScript strict mode passes
- [x] All 4155 tests pass with 100% line coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)