### PR TITLE
docs: update documentation for v1.1.0 features

### DIFF
--- a/.claude/PROJECT.md
+++ b/.claude/PROJECT.md
@@ -134,7 +134,7 @@ Module boundaries are enforced via `eslint-plugin-boundaries`:
 | Functions  | 99%+       |
 | Lines      | 99%+       |
 
-## Current Modules (36)
+## Current Modules (35)
 
 | Module       | Path                | Purpose                                                           |
 | ------------ | ------------------- | ----------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ tree-shakeable, and fully tested.
 - **Secure by default** — cryptographic randomness, input validation, XSS
   prevention
 - **Dual error handling** — throwing and Result-based APIs
-- **Quality-backed** — 3950+ tests, strict ESLint, full coverage
+- **Quality-backed** — 4150+ tests, strict ESLint, full coverage
 
 ## Modules
 

--- a/documentation/network.md
+++ b/documentation/network.md
@@ -102,6 +102,7 @@ const queue = RetryQueue.create({
 | `maxDelay`     | `number`          | `30000`         | Maximum delay cap          |
 | `networkAware` | `boolean`         | `true`          | Auto-pause when offline    |
 | `jitter`       | `boolean`         | `true`          | Add randomness to delays   |
+| `rateLimit`    | `RateLimitConfig` | `undefined`     | Rate limiting (see below)  |
 
 ### Backoff Strategies
 
@@ -110,6 +111,32 @@ const queue = RetryQueue.create({
 | `constant`    | Same delay every retry             |
 | `linear`      | Delay = baseDelay \* attempt       |
 | `exponential` | Delay = baseDelay \* 2^(attempt-1) |
+
+### Rate Limiting
+
+Prevents reconnect storms by limiting how many operations are processed within a
+sliding time window.
+
+| Option                 | Type     | Description                                   |
+| ---------------------- | -------- | --------------------------------------------- |
+| `maxRequestsPerWindow` | `number` | Maximum operations allowed in the time window |
+| `windowMs`             | `number` | Time window in milliseconds                   |
+
+```typescript
+const queue = RetryQueue.create({
+  maxRetries: 3,
+  backoff: 'exponential',
+  rateLimit: {
+    maxRequestsPerWindow: 10,
+    windowMs: 5000,
+  },
+});
+
+// Operations are automatically throttled to stay within the rate limit
+for (let i = 0; i < 100; i++) {
+  queue.add(async () => fetch(`/api/data/${i}`));
+}
+```
 
 ## Usage Examples
 

--- a/documentation/request.md
+++ b/documentation/request.md
@@ -36,6 +36,9 @@ api.destroy();
 | Request Timing        | Track request duration and performance          |
 | URL Validation        | Protocol allowlist and pattern blocking         |
 | Credential Protection | Prevent credential leakage to different origins |
+| Content-Type Check    | Validate response MIME type against expected    |
+| SSRF Protection       | Block requests to private/internal IP addresses |
+| Abort Signal Merge    | Combine multiple AbortSignals into one          |
 
 ## Types
 
@@ -52,6 +55,7 @@ api.destroy();
 | `HttpMethod`                 | HTTP method type                                  |
 | `RequestError`               | Request-specific error class                      |
 | `RequestErrorCode`           | Error code enum                                   |
+| `combineAbortSignals`        | Utility to merge two AbortSignals into one        |
 
 ## Configuration Options
 
@@ -65,6 +69,8 @@ api.destroy();
 | `allowedProtocols`         | `string[]`              | `['https:']` | Allowed URL protocols                    |
 | `blockedPatterns`          | `RegExp[]`              | `[]`         | URL patterns to block                    |
 | `validateCredentialOrigin` | `boolean`               | `true`       | Prevent credentials to different origins |
+| `blockPrivateIPs`          | `boolean`               | `false`      | Block requests to private/internal IPs   |
+| `expectedContentType`      | `string \| string[]`    | `undefined`  | Validate response Content-Type           |
 
 ## API Reference
 
@@ -372,21 +378,69 @@ api.use({
 });
 ```
 
+## Content-Type Validation
+
+Validate that responses have the expected MIME type. Fails closed — a missing
+`Content-Type` header with `expectedContentType` set will throw. Comparison is
+case-insensitive; parameters like `charset` are ignored.
+
+```typescript
+// Single MIME type — applied to all requests
+const api = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+  expectedContentType: 'application/json',
+});
+
+// Multiple accepted types
+const api2 = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+  expectedContentType: ['application/json', 'application/ld+json'],
+});
+
+// Override per-request
+const response = await api.fetch('/report.csv', {
+  expectedContentType: 'text/csv',
+});
+```
+
+## Combining Abort Signals
+
+Merge two `AbortSignal` instances into one. When either signal fires, the
+combined signal aborts and listeners on the other signal are cleaned up to
+prevent memory leaks.
+
+```typescript
+import { combineAbortSignals } from '@zappzarapp/browser-utils/request';
+
+const userController = new AbortController();
+const timeoutController = new AbortController();
+
+const combined = combineAbortSignals(
+  userController.signal,
+  timeoutController.signal
+);
+
+// Either signal aborting cancels the request
+const response = await api.fetch('/data', { signal: combined });
+```
+
 ## Error Handling
 
 ### Error Codes
 
-| Code                  | Description                                   |
-| --------------------- | --------------------------------------------- |
-| `FETCH_NOT_SUPPORTED` | Fetch API not available                       |
-| `INVALID_URL`         | URL validation failed                         |
-| `INVALID_CONFIG`      | Invalid configuration                         |
-| `REQUEST_FAILED`      | Network or fetch error                        |
-| `RESPONSE_ERROR`      | Non-2xx response (when `throwOnError: true`)  |
-| `MIDDLEWARE_ERROR`    | Error in middleware                           |
-| `TIMEOUT`             | Request timed out                             |
-| `ABORTED`             | Request was aborted                           |
-| `CREDENTIAL_LEAK`     | Attempted credential leak to different origin |
+| Code                    | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| `FETCH_NOT_SUPPORTED`   | Fetch API not available                       |
+| `INVALID_URL`           | URL validation failed                         |
+| `INVALID_CONFIG`        | Invalid configuration                         |
+| `REQUEST_FAILED`        | Network or fetch error                        |
+| `RESPONSE_ERROR`        | Non-2xx response (when `throwOnError: true`)  |
+| `MIDDLEWARE_ERROR`      | Error in middleware                           |
+| `TIMEOUT`               | Request timed out                             |
+| `ABORTED`               | Request was aborted                           |
+| `CREDENTIAL_LEAK`       | Attempted credential leak to different origin |
+| `SSRF_BLOCKED`          | Request to private/internal IP blocked        |
+| `CONTENT_TYPE_MISMATCH` | Response Content-Type does not match expected |
 
 ### Error Handling Example
 
@@ -403,6 +457,12 @@ try {
         break;
       case 'CREDENTIAL_LEAK':
         console.error('Security: credential leak prevented');
+        break;
+      case 'CONTENT_TYPE_MISMATCH':
+        console.error('Unexpected response type:', error.message);
+        break;
+      case 'SSRF_BLOCKED':
+        console.error('Security: private IP blocked');
         break;
       case 'INVALID_URL':
         console.error('Invalid URL:', error.message);
@@ -437,6 +497,13 @@ try {
 
 5. **No JavaScript/Data URLs** - The interceptor blocks `javascript:` and
    `data:` URLs as a defense-in-depth measure.
+
+6. **SSRF Protection** - Optionally block requests to private/internal IP
+   addresses (`blockPrivateIPs: true`). Covers IPv4 private ranges (10.x,
+   172.16-31.x, 192.168.x), loopback (127.x, ::1), and link-local.
+
+7. **Content-Type Validation** - Validate response MIME types to prevent
+   type-confusion attacks. Fails closed (missing header throws).
 
 ## Usage with Abort Controller
 

--- a/documentation/storage.md
+++ b/documentation/storage.md
@@ -30,13 +30,15 @@ const prefs = storage.get('prefs');
 
 ## Configuration Options
 
-| Option              | Type                            | Default     | Description                                       |
-| ------------------- | ------------------------------- | ----------- | ------------------------------------------------- |
-| `prefix`            | `string`                        | `'storage'` | Key prefix for all entries (alphanumeric)         |
-| `maxEntries`        | `number`                        | `50`        | Maximum entries before LRU eviction (1-10000)     |
-| `minSafeEntries`    | `number`                        | `5`         | Minimum entries to keep during emergency eviction |
-| `logger`            | `Logger \| LoggerConfigOptions` | Silent      | Logger for debug output                           |
-| `useMemoryFallback` | `boolean`                       | `true`      | Use memory storage when localStorage unavailable  |
+| Option              | Type                            | Default          | Description                                       |
+| ------------------- | ------------------------------- | ---------------- | ------------------------------------------------- |
+| `prefix`            | `string`                        | `'storage'`      | Key prefix for all entries (alphanumeric)         |
+| `maxEntries`        | `number`                        | `50`             | Maximum entries before LRU eviction (1-10000)     |
+| `minSafeEntries`    | `number`                        | `5`              | Minimum entries to keep during emergency eviction |
+| `logger`            | `Logger \| LoggerConfigOptions` | Silent           | Logger for debug output                           |
+| `useMemoryFallback` | `boolean`                       | `true`           | Use memory storage when localStorage unavailable  |
+| `serializer`        | `(value: unknown) => string`    | `JSON.stringify` | Custom function to serialize values               |
+| `deserializer`      | `(raw: string) => unknown`      | `JSON.parse`     | Custom function to deserialize values             |
 
 ## Factory Methods
 
@@ -144,6 +146,30 @@ const storage = StorageManager.fromConfig<MyData>(config);
 const entries = storage.entries();
 // Array<{ key: string; value: T; timestamp: number }>
 ```
+
+## Custom Serialization
+
+By default values are serialized with `JSON.stringify` / `JSON.parse`. To
+preserve non-JSON-native types (Date, Map, Set, RegExp, etc.) provide custom
+`serializer` and `deserializer` functions.
+
+```typescript
+const config = StorageConfig.create({
+  prefix: 'app',
+  serializer: (value) =>
+    JSON.stringify(value, (_key, v) =>
+      v instanceof Date ? { __date: v.toISOString() } : v
+    ),
+  deserializer: (raw) =>
+    JSON.parse(raw, (_key, v) => (v?.__date ? new Date(v.__date) : v)),
+});
+
+const storage = StorageManager.fromConfig<MyData>(config);
+```
+
+The `serializer` receives the full `StorageEntry<T>` object (with `data` and
+`timestamp`). The `deserializer` must return a value that matches the
+`StorageEntry<T>` shape.
 
 ## Cross-Tab Synchronization
 


### PR DESCRIPTION
## Summary

- **network.md**: add rate limiting config option and usage section
- **request.md**: add `expectedContentType`, `blockPrivateIPs`, `SSRF_BLOCKED`, `CONTENT_TYPE_MISMATCH`, `combineAbortSignals`, and security notes
- **storage.md**: add custom `serializer`/`deserializer` config and usage section
- **README.md**: update test count (3950+ → 4150+)
- **PROJECT.md**: fix module count (36 → 35)

## Test plan
- [x] Markdown linting passes
- [x] All code examples are syntactically correct and match current API

🤖 Generated with [Claude Code](https://claude.com/claude-code)