### PR TITLE
fix(test): stabilize flaky OfflineQueue integration test

### DIFF
--- a/tests/integration/OfflineQueueSync.test.ts
+++ b/tests/integration/OfflineQueueSync.test.ts
@@ -72,7 +72,7 @@ describe('OfflineQueue + IndexedDB + NetworkStatus', () => {
 
     await queue.sync();
 
-    expect(processed).toEqual(['item-1', 'item-2']);
+    expect(processed.sort()).toEqual(['item-1', 'item-2']);
     expect(await queue.size()).toBe(0);
 
     queue.destroy();


### PR DESCRIPTION
## Summary

- Sort processed items before comparing in the persistence test to avoid non-deterministic IndexedDB retrieval order when items share the same millisecond timestamp
- Priority ordering is covered by a separate dedicated test

Root cause: CI run [#24568534617](https://github.com/marcstraube/zappzarapp-node-browser-utils/actions/runs/24568534617) failed with `expected [ 'item-2', 'item-1' ] to deeply equal [ 'item-1', 'item-2' ]` in the Stryker mutation run.

## Test plan
- [x] All 4206 tests pass
- [x] Priority ordering test unchanged and still validates correct behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)