### PR TITLE
fix(ci): trigger npm publish on GitHub Release event

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - master
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Publish an existing release tag (e.g. v1.0.3)'
+        description: 'Publish an existing release tag (e.g. v1.1.0)'
         required: true
 
 permissions:
@@ -28,64 +30,27 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v4
-        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           release-type: node
 
-      # If a release was created, publish to npm
-      - name: Checkout code
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        if: ${{ steps.release.outputs.release_created }}
-        uses: pnpm/action-setup@v5
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Build package
-        if: ${{ steps.release.outputs.release_created }}
-        run: pnpm run build
-
-      - name: Update npm for OIDC trusted publishing
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm install -g npm@latest
-
-      - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --access public --provenance
-
-      - name: Generate SBOM
-        if: ${{ steps.release.outputs.release_created }}
-        run: pnpm run sbom
-
-      - name: Upload SBOM to release
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} sbom.cdx.json --clobber
-
   publish:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "ref=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ steps.tag.outputs.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
@@ -117,4 +82,4 @@ jobs:
       - name: Upload SBOM to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ inputs.tag }} sbom.cdx.json --clobber
+        run: gh release upload ${{ steps.tag.outputs.ref }} sbom.cdx.json --clobber


### PR DESCRIPTION
## Summary

- Decouple npm publish from release-please's `release_created` output, which is unreliable with squash-merge (SHA mismatch causes "SHA not found in recent commits" → publish skipped)
- Trigger publish on the `release: published` event instead
- `release-please` job now only manages PR/release creation
- `publish` job triggers on `release: published` or `workflow_dispatch` (manual fallback)
- Eliminates the need for manual re-publish after every release

## Test plan
- [x] Workflow syntax valid (YAML)
- [ ] Next release should auto-publish without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)