### PR TITLE
feat(request): add fetch streaming/progress utilities

### DIFF
--- a/documentation/request.md
+++ b/documentation/request.md
@@ -39,6 +39,7 @@ api.destroy();
 | Content-Type Check    | Validate response MIME type against expected    |
 | SSRF Protection       | Block requests to private/internal IP addresses |
 | Abort Signal Merge    | Combine multiple AbortSignals into one          |
+| Download Progress     | Track download progress via ReadableStream      |
 
 ## Types
 
@@ -56,6 +57,11 @@ api.destroy();
 | `RequestError`               | Request-specific error class                      |
 | `RequestErrorCode`           | Error code enum                                   |
 | `combineAbortSignals`        | Utility to merge two AbortSignals into one        |
+| `ProgressInfo`               | Progress data: loaded, total, percentage          |
+| `ProgressCallback`           | Progress event callback type                      |
+| `ProgressMiddlewareOptions`  | Options for progress middleware factory           |
+| `trackDownloadProgress`      | Wrap Response body to track download progress     |
+| `createProgressMiddleware`   | Middleware factory for download progress tracking |
 
 ## Configuration Options
 
@@ -424,6 +430,70 @@ const combined = combineAbortSignals(
 const response = await api.fetch('/data', { signal: combined });
 ```
 
+## Download Progress Tracking
+
+Track download progress by wrapping the response body ReadableStream. Progress
+is reported on each chunk with loaded bytes, total (from `Content-Length`), and
+percentage.
+
+### Standalone Usage
+
+```typescript
+import { trackDownloadProgress } from '@zappzarapp/browser-utils/request';
+
+const response = await fetch('https://example.com/large-file.zip');
+const tracked = trackDownloadProgress(response, (progress) => {
+  console.log(`${progress.loaded} / ${progress.total ?? '?'} bytes`);
+  if (progress.percentage !== null) {
+    updateProgressBar(progress.percentage);
+  }
+});
+
+// Progress is reported as the body is consumed
+const blob = await tracked.blob();
+```
+
+### With RequestInterceptor Middleware
+
+```typescript
+import {
+  RequestInterceptor,
+  createProgressMiddleware,
+} from '@zappzarapp/browser-utils/request';
+
+const api = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+});
+
+api.use(
+  createProgressMiddleware({
+    onDownloadProgress: (progress) => {
+      console.log(`Downloaded: ${progress.percentage ?? '?'}%`);
+    },
+  })
+);
+
+const response = await api.get('/files/large.zip');
+const blob = await response.blob();
+```
+
+### ProgressInfo
+
+| Property     | Type             | Description                                      |
+| ------------ | ---------------- | ------------------------------------------------ |
+| `loaded`     | `number`         | Bytes received so far                            |
+| `total`      | `number \| null` | Total bytes from Content-Length, null if unknown |
+| `percentage` | `number \| null` | Download percentage (0-100), null if unknown     |
+
+**Notes:**
+
+- If `Content-Length` is missing, `total` and `percentage` are `null`
+- Percentage is capped at 100 even if actual bytes exceed `Content-Length`
+- A final progress event is emitted when the stream ends
+- For responses with no body (e.g. 204), a single event is emitted with
+  `loaded: 0`
+- Stream cancellation propagates to the original response body
+
 ## Error Handling
 
 ### Error Codes
@@ -534,4 +604,5 @@ try {
 | Fetch API       | 42+    | 39+     | 10.1+  | 14+  |
 | AbortController | 66+    | 57+     | 11.1+  | 16+  |
 | Headers         | 42+    | 39+     | 10.1+  | 14+  |
+| ReadableStream  | 43+    | 65+     | 10.1+  | 14+  |
 | async/await     | 55+    | 52+     | 10.1+  | 14+  |

--- a/src/request/StreamProgress.ts
+++ b/src/request/StreamProgress.ts
@@ -1,0 +1,194 @@
+/**
+ * Stream Progress - Download progress tracking for fetch responses.
+ *
+ * Wraps a Response body ReadableStream to report download progress via callback.
+ * Works standalone or as RequestInterceptor middleware.
+ *
+ * @example Standalone usage
+ * ```TypeScript
+ * const response = await fetch('https://example.com/large-file.zip');
+ * const tracked = trackDownloadProgress(response, (progress) => {
+ *   console.log(`${progress.loaded} / ${progress.total ?? '?'} bytes`);
+ *   if (progress.percentage !== null) {
+ *     updateProgressBar(progress.percentage);
+ *   }
+ * });
+ * const blob = await tracked.blob();
+ * ```
+ *
+ * @example With RequestInterceptor middleware
+ * ```TypeScript
+ * const api = RequestInterceptor.create({
+ *   baseUrl: 'https://api.example.com',
+ * });
+ *
+ * api.use(createProgressMiddleware({
+ *   onDownloadProgress: (progress) => {
+ *     console.log(`Downloaded: ${progress.percentage ?? '?'}%`);
+ *   },
+ * }));
+ *
+ * const response = await api.get('/files/large.zip');
+ * await response.blob();
+ * ```
+ */
+import type { InterceptedResponse, RequestMiddleware } from './RequestInterceptor.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Progress information reported during download.
+ */
+export interface ProgressInfo {
+  /** Bytes received so far */
+  readonly loaded: number;
+  /** Total bytes expected (from Content-Length), or null if unknown */
+  readonly total: number | null;
+  /** Download percentage (0-100), or null if total is unknown */
+  readonly percentage: number | null;
+}
+
+/**
+ * Callback invoked on each chunk received.
+ */
+export type ProgressCallback = (progress: ProgressInfo) => void;
+
+/**
+ * Options for progress middleware.
+ */
+export interface ProgressMiddlewareOptions {
+  /** Callback invoked on each downloaded chunk */
+  readonly onDownloadProgress: ProgressCallback;
+}
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+/**
+ * Parse total bytes from Content-Length header.
+ * Returns null if header is missing, empty, or not a valid positive integer.
+ */
+function parseContentLength(headers: Headers): number | null {
+  const value = headers.get('Content-Length');
+  if (value === null || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Calculate percentage from loaded and total bytes.
+ * Returns null if total is unknown, 100 if total is 0 (empty response).
+ * Capped at 100 to handle Content-Length mismatches.
+ */
+function calculatePercentage(loaded: number, total: number | null): number | null {
+  if (total === null) {
+    return null;
+  }
+  if (total === 0) {
+    return 100;
+  }
+  return Math.min(Math.round((loaded / total) * 100), 100);
+}
+
+/**
+ * Wrap a Response's body stream to track download progress.
+ *
+ * Returns a new Response with the same status and headers but a body
+ * stream that reports progress to the callback on each chunk.
+ *
+ * If the response has no body (e.g. 204 No Content), the callback is
+ * invoked once with loaded=0 and the original response is returned.
+ *
+ * The progress stream supports cancellation — cancelling the returned
+ * response's body will propagate to the original stream.
+ *
+ * @param response - The fetch Response to track
+ * @param onProgress - Callback invoked on each chunk received
+ * @returns A new Response with progress-tracked body
+ */
+export function trackDownloadProgress(response: Response, onProgress: ProgressCallback): Response {
+  const total = parseContentLength(response.headers);
+
+  if (response.body === null) {
+    onProgress({
+      loaded: 0,
+      total,
+      percentage: calculatePercentage(0, total),
+    });
+    return response;
+  }
+
+  let loaded = 0;
+  const reader = response.body.getReader();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller): Promise<void> {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        onProgress({
+          loaded,
+          total,
+          percentage: total !== null ? 100 : null,
+        });
+        controller.close();
+        return;
+      }
+
+      loaded += value.byteLength;
+
+      onProgress({
+        loaded,
+        total,
+        percentage: calculatePercentage(loaded, total),
+      });
+
+      controller.enqueue(value);
+    },
+
+    cancel(reason?: unknown): Promise<void> {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(stream, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+/**
+ * Create a RequestMiddleware that tracks download progress.
+ *
+ * The middleware wraps the response body stream in the `onResponse` phase,
+ * so progress is reported as the consumer reads the body (e.g. via
+ * `response.json()`, `response.blob()`, or `response.body.getReader()`).
+ *
+ * @param options - Progress middleware options
+ * @returns A RequestMiddleware instance
+ */
+export function createProgressMiddleware(options: ProgressMiddlewareOptions): RequestMiddleware {
+  return {
+    onResponse(response: InterceptedResponse): InterceptedResponse {
+      const trackedResponse = trackDownloadProgress(response.response, options.onDownloadProgress);
+
+      return {
+        response: trackedResponse,
+        url: response.url,
+        duration: response.duration,
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      };
+    },
+  };
+}

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -14,3 +14,9 @@ export type {
   RequestInterceptorInstance,
 } from './RequestInterceptor.js';
 export { combineAbortSignals, validateContentType } from './RequestValidation.js';
+export { trackDownloadProgress, createProgressMiddleware } from './StreamProgress.js';
+export type {
+  ProgressInfo,
+  ProgressCallback,
+  ProgressMiddlewareOptions,
+} from './StreamProgress.js';

--- a/tests/request/StreamProgress.test.ts
+++ b/tests/request/StreamProgress.test.ts
@@ -1,0 +1,356 @@
+/**
+ * StreamProgress Tests.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  trackDownloadProgress,
+  createProgressMiddleware,
+  type ProgressInfo,
+  type InterceptedResponse,
+} from '../../src/request/index.js';
+
+/**
+ * Create a Response with a ReadableStream body from chunks.
+ */
+function createStreamResponse(
+  chunks: Uint8Array[],
+  options?: { contentLength?: number; status?: number; statusText?: string }
+): Response {
+  const headers = new Headers();
+  if (options?.contentLength !== undefined) {
+    headers.set('Content-Length', String(options.contentLength));
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers,
+    status: options?.status ?? 200,
+    statusText: options?.statusText ?? 'OK',
+  });
+}
+
+/**
+ * Create a Uint8Array of the given size filled with zeros.
+ */
+function createChunk(size: number): Uint8Array {
+  return new Uint8Array(size);
+}
+
+describe('StreamProgress', () => {
+  describe('trackDownloadProgress', () => {
+    it('should report progress for each chunk with known total', async () => {
+      const chunks = [createChunk(30), createChunk(30), createChunk(40)];
+      const response = createStreamResponse(chunks, { contentLength: 100 });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      expect(events).toEqual([
+        { loaded: 30, total: 100, percentage: 30 },
+        { loaded: 60, total: 100, percentage: 60 },
+        { loaded: 100, total: 100, percentage: 100 },
+        { loaded: 100, total: 100, percentage: 100 },
+      ]);
+    });
+
+    it('should report null percentage when Content-Length is missing', async () => {
+      const chunks = [createChunk(50), createChunk(50)];
+      const response = createStreamResponse(chunks);
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      expect(events).toEqual([
+        { loaded: 50, total: null, percentage: null },
+        { loaded: 100, total: null, percentage: null },
+        { loaded: 100, total: null, percentage: null },
+      ]);
+    });
+
+    it('should handle empty body (null stream)', async () => {
+      const response = new Response(null, {
+        status: 204,
+        statusText: 'No Content',
+      });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      expect(tracked).toBe(response);
+      expect(events).toEqual([{ loaded: 0, total: null, percentage: null }]);
+    });
+
+    it('should handle empty body with Content-Length 0', async () => {
+      const response = new Response(null, {
+        status: 204,
+        headers: { 'Content-Length': '0' },
+      });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      expect(tracked).toBe(response);
+      expect(events).toEqual([{ loaded: 0, total: 0, percentage: 100 }]);
+    });
+
+    it('should preserve response status and headers', async () => {
+      const chunks = [createChunk(10)];
+      const response = createStreamResponse(chunks, {
+        contentLength: 10,
+        status: 206,
+        statusText: 'Partial Content',
+      });
+
+      const tracked = trackDownloadProgress(response, vi.fn());
+
+      expect(tracked.status).toBe(206);
+      expect(tracked.statusText).toBe('Partial Content');
+      expect(tracked.headers.get('Content-Length')).toBe('10');
+    });
+
+    it('should return a new Response (not the original)', async () => {
+      const chunks = [createChunk(5)];
+      const response = createStreamResponse(chunks, { contentLength: 5 });
+
+      const tracked = trackDownloadProgress(response, vi.fn());
+
+      expect(tracked).not.toBe(response);
+    });
+
+    it('should cap percentage at 100 when actual exceeds Content-Length', async () => {
+      const chunks = [createChunk(60), createChunk(60)];
+      const response = createStreamResponse(chunks, { contentLength: 100 });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      expect(events[0]!.percentage).toBe(60);
+      expect(events[1]!.percentage).toBe(100);
+    });
+
+    it('should handle single-chunk download', async () => {
+      const chunks = [createChunk(100)];
+      const response = createStreamResponse(chunks, { contentLength: 100 });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      expect(events).toEqual([
+        { loaded: 100, total: 100, percentage: 100 },
+        { loaded: 100, total: 100, percentage: 100 },
+      ]);
+    });
+
+    it('should handle invalid Content-Length (non-numeric)', async () => {
+      const response = new Response(new Uint8Array(10), {
+        headers: { 'Content-Length': 'invalid' },
+      });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      for (const event of events) {
+        expect(event.total).toBeNull();
+        expect(event.percentage).toBeNull();
+      }
+    });
+
+    it('should handle negative Content-Length', async () => {
+      const response = new Response(new Uint8Array(10), {
+        headers: { 'Content-Length': '-5' },
+      });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      for (const event of events) {
+        expect(event.total).toBeNull();
+        expect(event.percentage).toBeNull();
+      }
+    });
+
+    it('should handle fractional Content-Length', async () => {
+      const response = new Response(new Uint8Array(10), {
+        headers: { 'Content-Length': '10.5' },
+      });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      for (const event of events) {
+        expect(event.total).toBeNull();
+        expect(event.percentage).toBeNull();
+      }
+    });
+
+    it('should propagate cancellation to the original stream', async () => {
+      const cancelFn = vi.fn();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(createChunk(10));
+          // Don't close — simulate long-running stream
+        },
+        cancel: cancelFn,
+      });
+
+      const response = new Response(stream, {
+        headers: { 'Content-Length': '1000' },
+      });
+
+      const tracked = trackDownloadProgress(response, vi.fn());
+      const reader = tracked.body!.getReader();
+
+      // Read one chunk
+      await reader.read();
+
+      // Cancel the stream
+      await reader.cancel('user cancelled');
+
+      expect(cancelFn).toHaveBeenCalledWith('user cancelled');
+    });
+
+    it('should produce readable body data', async () => {
+      const data = new TextEncoder().encode('Hello, World!');
+      const chunks = [data.slice(0, 5), data.slice(5)];
+      const response = createStreamResponse(chunks, {
+        contentLength: data.byteLength,
+      });
+
+      const tracked = trackDownloadProgress(response, vi.fn());
+      const text = await tracked.text();
+
+      expect(text).toBe('Hello, World!');
+    });
+
+    it('should emit final progress event on stream end', async () => {
+      const chunks = [createChunk(50)];
+      const response = createStreamResponse(chunks, { contentLength: 100 });
+      const events: ProgressInfo[] = [];
+
+      const tracked = trackDownloadProgress(response, (progress) => {
+        events.push(progress);
+      });
+
+      await tracked.arrayBuffer();
+
+      const lastEvent = events[events.length - 1]!;
+      expect(lastEvent.loaded).toBe(50);
+      expect(lastEvent.total).toBe(100);
+      expect(lastEvent.percentage).toBe(100);
+    });
+  });
+
+  describe('createProgressMiddleware', () => {
+    it('should return a middleware with onResponse handler', () => {
+      const middleware = createProgressMiddleware({
+        onDownloadProgress: vi.fn(),
+      });
+
+      expect(middleware.onResponse).toBeTypeOf('function');
+      expect(middleware.onRequest).toBeUndefined();
+      expect(middleware.onError).toBeUndefined();
+    });
+
+    it('should wrap response body with progress tracking', async () => {
+      const events: ProgressInfo[] = [];
+      const middleware = createProgressMiddleware({
+        onDownloadProgress: (progress) => events.push(progress),
+      });
+
+      const chunks = [createChunk(25), createChunk(75)];
+      const originalResponse = createStreamResponse(chunks, {
+        contentLength: 100,
+      });
+
+      const intercepted: InterceptedResponse = {
+        response: originalResponse,
+        url: 'https://example.com/file',
+        duration: 50,
+        status: 200,
+        statusText: 'OK',
+        headers: originalResponse.headers,
+      };
+
+      const result = middleware.onResponse!(intercepted) as InterceptedResponse;
+
+      expect(result.response).not.toBe(originalResponse);
+      expect(result.url).toBe('https://example.com/file');
+      expect(result.duration).toBe(50);
+      expect(result.status).toBe(200);
+      expect(result.statusText).toBe('OK');
+      expect(result.headers).toBe(intercepted.headers);
+
+      await result.response.arrayBuffer();
+
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0]!.loaded).toBe(25);
+      expect(events[0]!.total).toBe(100);
+    });
+
+    it('should preserve intercepted response metadata', () => {
+      const middleware = createProgressMiddleware({
+        onDownloadProgress: vi.fn(),
+      });
+
+      const originalResponse = new Response(null, { status: 204 });
+      const customHeaders = new Headers({ 'X-Custom': 'value' });
+
+      const intercepted: InterceptedResponse = {
+        response: originalResponse,
+        url: 'https://api.example.com/data',
+        duration: 123,
+        status: 204,
+        statusText: 'No Content',
+        headers: customHeaders,
+      };
+
+      const result = middleware.onResponse!(intercepted) as InterceptedResponse;
+
+      expect(result.url).toBe('https://api.example.com/data');
+      expect(result.duration).toBe(123);
+      expect(result.status).toBe(204);
+      expect(result.statusText).toBe('No Content');
+      expect(result.headers).toBe(customHeaders);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #10

- Add `trackDownloadProgress(response, callback)` — wraps Response body ReadableStream to report `{ loaded, total, percentage }` on each chunk
- Add `createProgressMiddleware({ onDownloadProgress })` — RequestInterceptor middleware factory for seamless integration
- Handle edge cases: missing Content-Length, empty bodies, Content-Length mismatches, stream cancellation, invalid headers

## Usage

```typescript
// Standalone
const tracked = trackDownloadProgress(response, ({ loaded, total, percentage }) => {
  updateProgressBar(percentage);
});
const blob = await tracked.blob();

// As middleware
api.use(createProgressMiddleware({
  onDownloadProgress: ({ percentage }) => updateUI(percentage),
}));
```

## Test plan

- [x] 17 tests covering all progress tracking scenarios
- [x] 100% line coverage
- [x] TypeScript strict, ESLint 0 warnings
- [x] Edge cases: null body, invalid Content-Length, cancellation propagation, data integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)