### PR TITLE
feat(cache): add onRevalidate callback for SWR completion notification

### DIFF
--- a/documentation/cache.md
+++ b/documentation/cache.md
@@ -95,6 +95,8 @@ interface CacheGetOptions<T> {
   readonly revalidate?: () => Promise<T>;
   /** Options for storing revalidated data */
   readonly revalidateOptions?: CacheSetOptions;
+  /** Callback invoked with fresh data when background revalidation completes */
+  readonly onRevalidate?: (value: T) => void;
 }
 
 interface CacheGetResult<T> {
@@ -206,6 +208,30 @@ if (result) {
   }
 }
 ```
+
+### Revalidation Notification
+
+Use `onRevalidate` to update your UI when fresh data arrives from a background
+revalidation:
+
+```typescript
+const result = await cache.get('api:users', {
+  staleWhileRevalidate: true,
+  revalidate: () => fetch('/api/users').then((r) => r.json()),
+  onRevalidate: (freshData) => {
+    // Called once background fetch completes successfully
+    renderUsers(freshData);
+    hideRefreshIndicator();
+  },
+});
+```
+
+The callback is **not** called when:
+
+- The entry is not stale (no revalidation needed)
+- The revalidation function throws an error (stale data remains)
+- The cache is destroyed before revalidation completes
+- The revalidation is deduplicated (only the first caller's callback fires)
 
 ### Tag-Based Invalidation
 

--- a/src/cache/CacheManager.ts
+++ b/src/cache/CacheManager.ts
@@ -143,6 +143,8 @@ export interface CacheGetOptions<T> {
   readonly revalidate?: () => Promise<T>;
   /** Options to use when storing revalidated data */
   readonly revalidateOptions?: CacheSetOptions;
+  /** Callback invoked with fresh data when background revalidation completes */
+  readonly onRevalidate?: (value: T) => void;
 }
 
 /**
@@ -464,6 +466,7 @@ export const CacheManager = {
               .then((freshValue) => {
                 if (!destroyed) {
                   instance.setSync(key, freshValue, options.revalidateOptions);
+                  options.onRevalidate?.(freshValue);
                 }
               })
               .catch(() => {

--- a/tests/cache/CacheManager.test.ts
+++ b/tests/cache/CacheManager.test.ts
@@ -518,6 +518,128 @@ describe('CacheManager', () => {
       // Revalidation should have been called but not stored
       expect(revalidateFn).toHaveBeenCalled();
     });
+
+    it('should call onRevalidate with fresh value after background revalidation', async () => {
+      const onRevalidate = vi.fn();
+      const revalidateFn = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return 'fresh-value';
+      });
+
+      cache.setSync('key1', 'stale-value', { staleAfter: 1000, ttl: 10000 });
+
+      vi.advanceTimersByTime(1001);
+
+      const result = await cache.get('key1', {
+        staleWhileRevalidate: true,
+        revalidate: revalidateFn,
+        onRevalidate,
+      });
+
+      expect(result?.value).toBe('stale-value');
+      expect(onRevalidate).not.toHaveBeenCalled();
+
+      await vi.runAllTimersAsync();
+
+      expect(onRevalidate).toHaveBeenCalledTimes(1);
+      expect(onRevalidate).toHaveBeenCalledWith('fresh-value');
+    });
+
+    it('should not call onRevalidate on revalidation error', async () => {
+      const onRevalidate = vi.fn();
+      const revalidateFn = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      cache.setSync('key1', 'stale-value', { staleAfter: 1000, ttl: 10000 });
+
+      vi.advanceTimersByTime(1001);
+
+      await cache.get('key1', {
+        staleWhileRevalidate: true,
+        revalidate: revalidateFn,
+        onRevalidate,
+      });
+
+      await vi.runAllTimersAsync();
+
+      expect(onRevalidate).not.toHaveBeenCalled();
+    });
+
+    it('should not call onRevalidate if cache is destroyed before revalidation completes', async () => {
+      const onRevalidate = vi.fn();
+      const revalidateFn = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return 'fresh-value';
+      });
+
+      cache.setSync('key1', 'stale-value', { staleAfter: 1000, ttl: 10000 });
+
+      vi.advanceTimersByTime(1001);
+
+      const resultPromise = cache.get('key1', {
+        staleWhileRevalidate: true,
+        revalidate: revalidateFn,
+        onRevalidate,
+      });
+
+      cache.destroy();
+
+      await resultPromise;
+      await vi.runAllTimersAsync();
+
+      expect(onRevalidate).not.toHaveBeenCalled();
+    });
+
+    it('should not call onRevalidate when entry is not stale', async () => {
+      const onRevalidate = vi.fn();
+      const revalidateFn = vi.fn().mockResolvedValue('fresh-value');
+
+      cache.setSync('key1', 'value1', { staleAfter: 5000, ttl: 10000 });
+
+      const result = await cache.get('key1', {
+        staleWhileRevalidate: true,
+        revalidate: revalidateFn,
+        onRevalidate,
+      });
+
+      expect(result?.value).toBe('value1');
+      expect(result?.isStale).toBe(false);
+
+      await vi.runAllTimersAsync();
+
+      expect(revalidateFn).not.toHaveBeenCalled();
+      expect(onRevalidate).not.toHaveBeenCalled();
+    });
+
+    it('should call onRevalidate only once with deduplication', async () => {
+      const onRevalidate = vi.fn();
+      const revalidateFn = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return 'fresh-value';
+      });
+
+      cache.setSync('key1', 'stale-value', { staleAfter: 1000, ttl: 10000 });
+
+      vi.advanceTimersByTime(1001);
+
+      // Multiple concurrent gets with onRevalidate
+      await Promise.all([
+        cache.get('key1', {
+          staleWhileRevalidate: true,
+          revalidate: revalidateFn,
+          onRevalidate,
+        }),
+        cache.get('key1', {
+          staleWhileRevalidate: true,
+          revalidate: revalidateFn,
+          onRevalidate,
+        }),
+      ]);
+
+      await vi.runAllTimersAsync();
+
+      expect(revalidateFn).toHaveBeenCalledTimes(1);
+      expect(onRevalidate).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

Closes #8

- Add optional `onRevalidate` callback to `CacheGetOptions<T>`, invoked with fresh data when background stale-while-revalidate fetch completes
- Enables reactive UIs to update when revalidation finishes without polling

## Usage

```typescript
const result = await cache.get('api:users', {
  staleWhileRevalidate: true,
  revalidate: () => fetch('/api/users').then((r) => r.json()),
  onRevalidate: (freshData) => {
    renderUsers(freshData);
    hideRefreshIndicator();
  },
});
```

The callback is **not** called when:
- Entry is not stale (no revalidation needed)
- Revalidation throws (stale data remains)
- Cache is destroyed before completion
- Revalidation is deduplicated (only first caller's callback fires)

## Test plan

- [x] 5 new tests covering callback invocation, error case, destroy, non-stale, deduplication
- [x] All 4228 tests pass, 100% line coverage
- [x] TypeScript strict, ESLint 0 warnings
- [x] Documentation updated in `documentation/cache.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)