### PR TITLE
security: pin fast-uri and qs to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   smol-toml: '>=1.6.1'
+  fast-uri: '>=3.1.2'
+  qs: '>=6.15.2'
 
 importers:
 
@@ -2075,9 +2077,6 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -3044,10 +3043,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
-    engines: {node: '>=0.6'}
 
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
@@ -5188,7 +5183,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5864,8 +5859,6 @@ snapshots:
   fast-string-width@3.0.2:
     dependencies:
       fast-string-truncated-width: 3.0.3
-
-  fast-uri@3.1.0: {}
 
   fast-uri@3.1.2: {}
 
@@ -6871,14 +6864,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
-    optional: true
 
   queue-microtask@1.2.3: {}
 
@@ -7288,7 +7276,7 @@ snapshots:
     dependencies:
       des.js: 1.1.0
       js-md4: 0.3.2
-      qs: 6.15.1
+      qs: 6.15.2
       tunnel: 0.0.6
       underscore: 1.13.8
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,8 @@
 overrides:
   '@isaacs/brace-expansion': '>=5.0.1'
   smol-toml: '>=1.6.1'
+  fast-uri: '>=3.1.2'
+  qs: '>=6.15.2'
 
 allowBuilds:
   esbuild: false


### PR DESCRIPTION
## Summary

Force three transitive **dev-only** dependencies to patched versions via pnpm `overrides`, closing the open Dependabot alerts ahead of the 2.0.0 release.

| Package | Pinned | Alert | Severity |
| ------- | ------ | ----- | -------- |
| `fast-uri` | `>=3.1.2` | path traversal via percent-encoded dot segments | **high** |
| `fast-uri` | `>=3.1.2` | host confusion via percent-encoded authority delimiters | **high** |
| `qs` | `>=6.15.2` | DoS in `qs.stringify` on null/undefined comma-array entries | moderate |

These are pulled transitively by `@cyclonedx/cdxgen` (SBOM) and the Stryker toolchain — they never reach published consumers, but the audit should be clean.

## Implementation

Added to `pnpm-workspace.yaml` `overrides` (the override location since the pnpm 11 migration). Lockfile regenerated under pnpm 11: the vulnerable `fast-uri@3.1.0` and `qs@6.15.1` are gone; only the patched versions remain.

## Verification

`pnpm run quality` (format, lint, typecheck, tests, build, size-limits, audit) is green locally with the overrides applied. The Dependabot alerts auto-resolve once the vulnerable versions leave `master`.
