### PR TITLE
feat!: unify DeviceInfo orientation API into immutable OrientationState (#125)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,11 +20,66 @@ If you cannot upgrade to Node.js 22, stay on the `1.x` line. Note that `1.x` is
 no longer maintained (it runs on an end-of-life runtime) — see
 [SECURITY.md](./SECURITY.md).
 
-### No public API changes
+### Orientation API (breaking)
 
-2.0 introduces **no breaking changes to the runtime API** of the published
-modules. The package remains **ESM-only** (as it has been since 1.x) — it cannot
-be `require()`'d from CommonJS. Import paths and exports are unchanged.
+The `DeviceInfo` orientation sub-API has been unified into a single immutable,
+fully-typed `OrientationState`. One getter and one listener now share the same
+shape. The legacy `window.resize` fallback was dropped — the API is built purely
+on the
+[Screen Orientation API](https://developer.mozilla.org/docs/Web/API/Screen_Orientation_API)
+(baseline: Safari/iOS 16.4+, March 2023). When unsupported, the getter returns
+`undefined` and the listener is a no-op.
+
+```ts
+interface OrientationState {
+  readonly type: OrientationType; // 'portrait-primary' | 'landscape-primary' | …
+  readonly angle: number; // 0 | 90 | 180 | 270
+  readonly orientation: Orientation; // 'portrait' | 'landscape' (derived)
+}
+```
+
+**`getOrientation()` now returns an `OrientationState`:**
+
+```ts
+// Before
+const type = DeviceInfo.getOrientation(); // OrientationType | undefined
+
+// After
+const state = DeviceInfo.getOrientation(); // OrientationState | undefined
+state?.type; // OrientationType
+state?.angle; // number
+state?.orientation; // 'portrait' | 'landscape'
+```
+
+**`onOrientationChange()` now passes an `OrientationState`:**
+
+```ts
+// Before
+DeviceInfo.onOrientationChange((orientation) => {
+  console.log(orientation); // 'portrait' | 'landscape'
+});
+
+// After
+DeviceInfo.onOrientationChange((state) => {
+  console.log(state.type, state.angle, state.orientation);
+});
+```
+
+**Removed methods** — all subsumed by the two above:
+
+| Removed                     | Replacement                                               |
+| --------------------------- | --------------------------------------------------------- |
+| `orientation()`             | `getOrientation()?.orientation`                           |
+| `orientationAngle()`        | `getOrientation()?.angle`                                 |
+| `onOrientationTypeChange()` | `onOrientationChange()` — the handler already gets `type` |
+
+`isOrientationSupported()`, `lockOrientation()`, and `unlockOrientation()` are
+unchanged.
+
+### No other public API changes
+
+Apart from the orientation redesign above, 2.0 introduces **no breaking changes
+to the runtime API** of the published modules.
 
 ### For contributors
 

--- a/documentation/device.md
+++ b/documentation/device.md
@@ -22,8 +22,8 @@ const viewport = DeviceInfo.viewportSize();
 console.log(`Viewport: ${viewport.width}x${viewport.height}`);
 
 // Orientation changes
-const cleanup = DeviceInfo.onOrientationChange((orientation) => {
-  console.log(`Orientation: ${orientation}`);
+const cleanup = DeviceInfo.onOrientationChange((state) => {
+  console.log(`${state.type} @ ${state.angle}° (${state.orientation})`);
 });
 ```
 
@@ -59,13 +59,22 @@ const cleanup = DeviceInfo.onOrientationChange((orientation) => {
 
 ### Orientation
 
-| Method                         | Returns            | Description                             |
-| ------------------------------ | ------------------ | --------------------------------------- |
-| `orientation()`                | `Orientation`      | Get current orientation                 |
-| `orientationAngle()`           | `number`           | Get orientation angle (0, 90, 180, 270) |
-| `onOrientationChange(handler)` | `CleanupFn`        | Listen for orientation changes          |
-| `lockOrientation(orientation)` | `Promise<boolean>` | Lock orientation (if supported)         |
-| `unlockOrientation()`          | `void`             | Unlock orientation                      |
+Built on the
+[Screen Orientation API](https://developer.mozilla.org/docs/Web/API/Screen_Orientation_API)
+(baseline: Safari/iOS 16.4+, March 2023). When the API is unsupported,
+`getOrientation()` returns `undefined` and `onOrientationChange()` is a no-op —
+there is no legacy fallback.
+
+| Method                         | Returns                         | Description                                      |
+| ------------------------------ | ------------------------------- | ------------------------------------------------ |
+| `isOrientationSupported()`     | `boolean`                       | Check if the Screen Orientation API is available |
+| `getOrientation()`             | `OrientationState \| undefined` | Get an immutable snapshot of the orientation     |
+| `onOrientationChange(handler)` | `CleanupFn`                     | Listen for orientation changes                   |
+| `lockOrientation(orientation)` | `Promise<void>`                 | Lock orientation (rejects if unsupported)        |
+| `unlockOrientation()`          | `void`                          | Unlock orientation                               |
+
+The handler passed to `onOrientationChange` receives the new `OrientationState`
+on every change. Use `getOrientation()` for the initial snapshot.
 
 ### Browser Features
 
@@ -81,6 +90,18 @@ const cleanup = DeviceInfo.onOrientationChange((orientation) => {
 
 ```typescript
 type Orientation = 'portrait' | 'landscape';
+
+type OrientationType =
+  | 'portrait-primary'
+  | 'portrait-secondary'
+  | 'landscape-primary'
+  | 'landscape-secondary';
+
+interface OrientationState {
+  readonly type: OrientationType; // full type, e.g. 'portrait-primary'
+  readonly angle: number; // 0 | 90 | 180 | 270
+  readonly orientation: Orientation; // derived: 'portrait' | 'landscape'
+}
 
 interface Size {
   readonly width: number;
@@ -165,12 +186,15 @@ function loadResponsiveImage(basePath: string): string {
 
 ```typescript
 function setupOrientationHandling(): CleanupFn {
-  // Get initial orientation
-  updateLayout(DeviceInfo.orientation());
+  // Apply the initial snapshot (may be undefined if unsupported)
+  const initial = DeviceInfo.getOrientation();
+  if (initial) {
+    updateLayout(initial.orientation);
+  }
 
   // Listen for changes
-  return DeviceInfo.onOrientationChange((orientation) => {
-    updateLayout(orientation);
+  return DeviceInfo.onOrientationChange((state) => {
+    updateLayout(state.orientation);
   });
 }
 
@@ -190,14 +214,14 @@ function updateLayout(orientation: Orientation): void {
 ```typescript
 async function initGame(): Promise<void> {
   // Try to lock to landscape for game
-  const locked = await DeviceInfo.lockOrientation('landscape');
-
-  if (!locked) {
+  try {
+    await DeviceInfo.lockOrientation('landscape');
+  } catch {
     showOrientationPrompt('Please rotate your device to landscape mode');
 
     // Listen for correct orientation
-    const cleanup = DeviceInfo.onOrientationChange((orientation) => {
-      if (orientation === 'landscape') {
+    const cleanup = DeviceInfo.onOrientationChange((state) => {
+      if (state.orientation === 'landscape') {
         hideOrientationPrompt();
         cleanup();
       }

--- a/examples/device-info.ts
+++ b/examples/device-info.ts
@@ -16,12 +16,7 @@
  */
 
 import { type CleanupFn } from '@zappzarapp/browser-utils/core';
-import {
-  DeviceInfo,
-  type Orientation,
-  type OrientationType,
-  type Size,
-} from '@zappzarapp/browser-utils/device';
+import { DeviceInfo, type OrientationState, type Size } from '@zappzarapp/browser-utils/device';
 import { Logger } from '@zappzarapp/browser-utils/logging';
 
 // =============================================================================
@@ -38,7 +33,7 @@ interface DeviceProfile {
   readonly screen: Size;
   readonly viewport: Size;
   readonly pixelRatio: number;
-  readonly orientation: Orientation;
+  readonly orientation: OrientationState | undefined;
   readonly memory: number | null;
   readonly cpuCores: number;
   readonly languages: readonly string[];
@@ -172,18 +167,18 @@ function displayScreenInfo(): void {
 function displayOrientationInfo(): void {
   console.log('\n--- Orientation Information ---');
 
-  const orientation = DeviceInfo.orientation();
-  const angle = DeviceInfo.orientationAngle();
   const isSupported = DeviceInfo.isOrientationSupported();
-  const orientationType = DeviceInfo.getOrientation();
-
   console.log(`Orientation API supported: ${isSupported}`);
-  console.log(`Current orientation: ${orientation}`);
-  console.log(`Orientation angle: ${angle} degrees`);
 
-  if (orientationType !== undefined) {
-    console.log(`Full orientation type: ${orientationType}`);
+  const state = DeviceInfo.getOrientation();
+  if (state === undefined) {
+    console.log('No orientation snapshot available');
+    return;
   }
+
+  console.log(`Current orientation: ${state.orientation}`);
+  console.log(`Full orientation type: ${state.type}`);
+  console.log(`Orientation angle: ${state.angle} degrees`);
 
   // Explain angles
   console.log('\nOrientation angles:');
@@ -194,44 +189,23 @@ function displayOrientationInfo(): void {
 }
 
 /**
- * Monitor orientation changes (simplified portrait/landscape).
+ * Monitor orientation changes via the immutable OrientationState.
  */
 function monitorOrientationChange(): CleanupFn {
   console.log('\n--- Orientation Change Monitor ---');
 
-  const cleanup = DeviceInfo.onOrientationChange((orientation: Orientation) => {
-    console.log(`[Orientation] Changed to: ${orientation}`);
+  const cleanup = DeviceInfo.onOrientationChange((state) => {
+    console.log(`[Orientation] Changed to: ${state.type} @ ${state.angle}°`);
 
-    // Respond to orientation change
-    if (orientation === 'landscape') {
+    // Coarse layout hint from the derived orientation
+    if (state.orientation === 'landscape') {
       console.log('  Tip: Consider hiding navigation for more space');
     } else {
       console.log('  Tip: Full navigation visible');
     }
-  });
 
-  console.log('Monitoring orientation changes...');
-  console.log('Rotate your device to see events');
-
-  return cleanup;
-}
-
-/**
- * Monitor full orientation type changes.
- */
-function monitorOrientationTypeChange(): CleanupFn {
-  console.log('\n--- Full Orientation Type Monitor ---');
-
-  if (!DeviceInfo.isOrientationSupported()) {
-    console.log('Screen Orientation API not supported');
-    return () => {};
-  }
-
-  const cleanup = DeviceInfo.onOrientationTypeChange((type: OrientationType) => {
-    console.log(`[Orientation] Type changed to: ${type}`);
-
-    // More specific handling
-    switch (type) {
+    // Fine-grained handling from the full type
+    switch (state.type) {
       case 'portrait-primary':
         console.log('  Normal portrait mode');
         break;
@@ -247,7 +221,8 @@ function monitorOrientationTypeChange(): CleanupFn {
     }
   });
 
-  console.log('Monitoring full orientation type changes...');
+  console.log('Monitoring orientation changes...');
+  console.log('Rotate your device to see events');
 
   return cleanup;
 }
@@ -365,7 +340,7 @@ function buildDeviceProfile(): DeviceProfile {
     screen: DeviceInfo.screenSize(),
     viewport: DeviceInfo.viewportSize(),
     pixelRatio: DeviceInfo.pixelRatio(),
-    orientation: DeviceInfo.orientation(),
+    orientation: DeviceInfo.getOrientation(),
     memory: DeviceInfo.deviceMemory(),
     cpuCores: DeviceInfo.hardwareConcurrency(),
     languages: DeviceInfo.languages(),
@@ -444,7 +419,7 @@ class ResponsiveManager {
       screen: DeviceInfo.screenSize(),
       viewport: DeviceInfo.viewportSize(),
       pixelRatio: DeviceInfo.pixelRatio(),
-      orientation: DeviceInfo.orientation(),
+      orientation: DeviceInfo.getOrientation(),
       memory: DeviceInfo.deviceMemory(),
       cpuCores: DeviceInfo.hardwareConcurrency(),
       languages: DeviceInfo.languages(),
@@ -457,8 +432,8 @@ class ResponsiveManager {
    */
   private setupListeners(): void {
     // Listen for orientation changes
-    const orientationCleanup = DeviceInfo.onOrientationChange((orientation) => {
-      this.logger.info(`Orientation changed to: ${orientation}`);
+    const orientationCleanup = DeviceInfo.onOrientationChange((state) => {
+      this.logger.info(`Orientation changed to: ${state.type}`);
       this.profile = this.captureProfile();
       this.onProfileChange();
     });
@@ -734,7 +709,6 @@ export async function runDeviceInfoExamples(): Promise<{ cleanup: () => void }> 
   displayScreenInfo();
   displayOrientationInfo();
   cleanups.push(monitorOrientationChange());
-  cleanups.push(monitorOrientationTypeChange());
   await orientationLockExample();
   displayDeviceCapabilities();
   buildDeviceProfile();

--- a/src/device/DeviceInfo.ts
+++ b/src/device/DeviceInfo.ts
@@ -24,8 +24,8 @@
  * const viewport = DeviceInfo.viewportSize();
  *
  * // Orientation
- * const cleanup = DeviceInfo.onOrientationChange((orientation) => {
- *   console.log(orientation); // 'portrait' | 'landscape'
+ * const cleanup = DeviceInfo.onOrientationChange((state) => {
+ *   console.log(state.type, state.angle, state.orientation);
  * });
  * ```
  */
@@ -78,6 +78,32 @@ export type OrientationLockType =
 export interface Size {
   readonly width: number;
   readonly height: number;
+}
+
+/**
+ * Immutable snapshot of the device's screen orientation.
+ *
+ * Combines the full {@link OrientationType} and angle from the Screen
+ * Orientation API with a derived {@link Orientation} convenience field.
+ */
+export interface OrientationState {
+  /** Full orientation type, e.g. `'portrait-primary'`. */
+  readonly type: OrientationType;
+  /** Orientation angle in degrees: `0`, `90`, `180`, or `270`. */
+  readonly angle: number;
+  /** Derived coarse orientation: `'portrait'` or `'landscape'`. */
+  readonly orientation: Orientation;
+}
+
+/**
+ * Build an immutable {@link OrientationState} from a live `ScreenOrientation`.
+ */
+function toOrientationState(source: ScreenOrientation): OrientationState {
+  return {
+    type: source.type,
+    angle: source.angle,
+    orientation: source.type.startsWith('portrait') ? 'portrait' : 'landscape',
+  };
 }
 
 export const DeviceInfo = {
@@ -284,122 +310,51 @@ export const DeviceInfo = {
 
   /**
    * Check if the Screen Orientation API is supported.
-   * @returns true if Screen Orientation API is available
+   *
+   * Baseline: Safari/iOS 16.4+ (March 2023) — available in all current
+   * evergreen browsers.
+   * @returns true if the Screen Orientation API is available
    */
   isOrientationSupported(): boolean {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- Browser compatibility
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- screen.orientation is absent on unsupported engines
     return typeof screen !== 'undefined' && !!screen.orientation;
   },
 
   /**
-   * Get the current orientation type from the Screen Orientation API.
-   * @returns The full orientation type or undefined if not supported
+   * Get an immutable snapshot of the current orientation.
+   * @returns The current {@link OrientationState}, or `undefined` when the
+   *   Screen Orientation API is unsupported.
    */
-  getOrientation(): OrientationType | undefined {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen === 'undefined' || !screen.orientation) {
+  getOrientation(): OrientationState | undefined {
+    if (!DeviceInfo.isOrientationSupported()) {
       return undefined;
     }
 
-    return screen.orientation.type;
+    return toOrientationState(screen.orientation);
   },
 
   /**
-   * Get current orientation.
+   * Listen for orientation changes.
+   *
+   * The handler receives an immutable {@link OrientationState} on every change.
+   * When the Screen Orientation API is unsupported the listener is a no-op and
+   * the returned cleanup does nothing.
+   * @param handler - Called with the new state whenever the orientation changes
+   * @returns Cleanup function that removes the listener
    */
-  orientation(): Orientation {
-    if (typeof window === 'undefined') {
-      return 'portrait';
-    }
-
-    // Try Screen Orientation API first
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen !== 'undefined' && screen.orientation) {
-      return screen.orientation.type.includes('portrait') ? 'portrait' : 'landscape';
-    }
-
-    // Fallback to comparing dimensions
-    return window.innerHeight > window.innerWidth ? 'portrait' : 'landscape';
-  },
-
-  /**
-   * Get orientation angle.
-   */
-  orientationAngle(): number {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen !== 'undefined' && screen.orientation) {
-      return screen.orientation.angle;
-    }
-
-    return 0;
-  },
-
-  /**
-   * Listen for orientation changes (simplified portrait/landscape).
-   * @param handler - Called when orientation changes
-   * @returns Cleanup function
-   * @deprecated Use onOrientationTypeChange for full OrientationType support
-   */
-  onOrientationChange(handler: (orientation: Orientation) => void): CleanupFn {
-    if (typeof window === 'undefined') {
+  onOrientationChange(handler: (state: OrientationState) => void): CleanupFn {
+    if (!DeviceInfo.isOrientationSupported()) {
       return () => {};
     }
 
-    let lastOrientation = DeviceInfo.orientation();
-
-    const checkOrientation = (): void => {
-      const currentOrientation = DeviceInfo.orientation();
-      if (currentOrientation !== lastOrientation) {
-        lastOrientation = currentOrientation;
-        handler(currentOrientation);
-      }
+    const { orientation } = screen;
+    const onChange = (): void => {
+      handler(toOrientationState(orientation));
     };
 
-    // Use Screen Orientation API if available
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen !== 'undefined' && screen.orientation) {
-      screen.orientation.addEventListener('change', checkOrientation);
-      return () => {
-        screen.orientation.removeEventListener('change', checkOrientation);
-      };
-    }
-
-    // Fallback to resize event
-    window.addEventListener('resize', checkOrientation);
+    orientation.addEventListener('change', onChange);
     return () => {
-      window.removeEventListener('resize', checkOrientation);
-    };
-  },
-
-  /**
-   * Listen for orientation type changes with full OrientationType.
-   * Only works when Screen Orientation API is supported.
-   * @param handler - Called when orientation changes with the full OrientationType
-   * @returns Cleanup function
-   */
-  onOrientationTypeChange(handler: (orientation: OrientationType) => void): CleanupFn {
-    if (typeof window === 'undefined') {
-      return () => {};
-    }
-
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen === 'undefined' || !screen.orientation) {
-      return () => {};
-    }
-
-    let lastOrientation = screen.orientation.type;
-
-    const checkOrientation = (): void => {
-      const currentOrientation = screen.orientation.type;
-      if (currentOrientation !== lastOrientation) {
-        lastOrientation = currentOrientation;
-        handler(currentOrientation);
-      }
-    };
-
-    screen.orientation.addEventListener('change', checkOrientation);
-    return () => {
-      screen.orientation.removeEventListener('change', checkOrientation);
+      orientation.removeEventListener('change', onChange);
     };
   },
 
@@ -409,8 +364,7 @@ export const DeviceInfo = {
    * @throws Error if orientation lock is not supported or fails
    */
   async lockOrientation(orientation: OrientationLockType): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen === 'undefined' || !screen.orientation) {
+    if (!DeviceInfo.isOrientationSupported()) {
       throw new Error('Screen Orientation API is not supported');
     }
 
@@ -424,8 +378,7 @@ export const DeviceInfo = {
    * Unlock orientation.
    */
   unlockOrientation(): void {
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-unnecessary-condition -- Browser compatibility
-    if (typeof screen !== 'undefined' && screen.orientation) {
+    if (DeviceInfo.isOrientationSupported()) {
       screen.orientation.unlock();
     }
   },

--- a/src/device/index.ts
+++ b/src/device/index.ts
@@ -1,2 +1,8 @@
 export { DeviceInfo } from './DeviceInfo.js';
-export type { Orientation, OrientationLockType, OrientationType, Size } from './DeviceInfo.js';
+export type {
+  Orientation,
+  OrientationLockType,
+  OrientationState,
+  OrientationType,
+  Size,
+} from './DeviceInfo.js';

--- a/tests/device/DeviceInfo.test.ts
+++ b/tests/device/DeviceInfo.test.ts
@@ -3,6 +3,7 @@ import {
   DeviceInfo,
   type Orientation,
   type OrientationLockType,
+  type OrientationState,
   type OrientationType,
   type Size,
 } from '../../src/device/index.js';
@@ -228,12 +229,12 @@ describe('DeviceInfo', () => {
       expect(DeviceInfo.pixelRatio()).toBe(1);
     });
 
-    it('orientation should return portrait', () => {
-      expect(DeviceInfo.orientation()).toBe('portrait');
+    it('isOrientationSupported should return false', () => {
+      expect(DeviceInfo.isOrientationSupported()).toBe(false);
     });
 
-    it('orientationAngle should return 0', () => {
-      expect(DeviceInfo.orientationAngle()).toBe(0);
+    it('getOrientation should return undefined', () => {
+      expect(DeviceInfo.getOrientation()).toBeUndefined();
     });
 
     it('onOrientationChange should return no-op cleanup function', () => {
@@ -244,14 +245,6 @@ describe('DeviceInfo', () => {
       expect(handler).not.toHaveBeenCalled();
     });
 
-    it('isOrientationSupported should return false', () => {
-      expect(DeviceInfo.isOrientationSupported()).toBe(false);
-    });
-
-    it('getOrientation should return undefined', () => {
-      expect(DeviceInfo.getOrientation()).toBeUndefined();
-    });
-
     it('lockOrientation should throw error', async () => {
       await expect(DeviceInfo.lockOrientation('portrait')).rejects.toThrow(
         'Screen Orientation API is not supported'
@@ -260,14 +253,6 @@ describe('DeviceInfo', () => {
 
     it('unlockOrientation should not throw', () => {
       expect(() => DeviceInfo.unlockOrientation()).not.toThrow();
-    });
-
-    it('onOrientationTypeChange should return no-op cleanup function', () => {
-      const handler = vi.fn();
-      const cleanup = DeviceInfo.onOrientationTypeChange(handler);
-      expect(typeof cleanup).toBe('function');
-      cleanup();
-      expect(handler).not.toHaveBeenCalled();
     });
 
     it('languages should return empty array', () => {
@@ -1214,73 +1199,32 @@ describe('DeviceInfo', () => {
     });
 
     describe('getOrientation', () => {
-      it('should return the full orientation type when supported', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-primary',
-              angle: 0,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
+      const states = [
+        { type: 'portrait-primary', angle: 0, orientation: 'portrait' },
+        { type: 'landscape-primary', angle: 90, orientation: 'landscape' },
+        { type: 'portrait-secondary', angle: 180, orientation: 'portrait' },
+        { type: 'landscape-secondary', angle: 270, orientation: 'landscape' },
+      ] as const satisfies readonly OrientationState[];
 
-        expect(DeviceInfo.getOrientation()).toBe('portrait-primary');
-      });
+      it.each(states)(
+        'should expose $type as an immutable state with derived orientation',
+        ({ type, angle, orientation }) => {
+          Object.defineProperty(globalThis, 'screen', {
+            value: createMockScreen({
+              orientation: {
+                type,
+                angle,
+                addEventListener: vi.fn(),
+                removeEventListener: vi.fn(),
+              } as unknown as ScreenOrientation,
+            }),
+            writable: true,
+            configurable: true,
+          });
 
-      it('should return landscape-primary', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'landscape-primary',
-              angle: 0,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.getOrientation()).toBe('landscape-primary');
-      });
-
-      it('should return portrait-secondary', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-secondary',
-              angle: 180,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.getOrientation()).toBe('portrait-secondary');
-      });
-
-      it('should return landscape-secondary', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'landscape-secondary',
-              angle: 270,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.getOrientation()).toBe('landscape-secondary');
-      });
+          expect(DeviceInfo.getOrientation()).toEqual({ type, angle, orientation });
+        }
+      );
 
       it('should return undefined when not supported', () => {
         Object.defineProperty(globalThis, 'screen', {
@@ -1303,170 +1247,11 @@ describe('DeviceInfo', () => {
       });
     });
 
-    describe('orientation', () => {
-      it('should return portrait when screen.orientation.type is portrait-primary', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-primary',
-              angle: 0,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('portrait');
-      });
-
-      it('should return portrait when screen.orientation.type is portrait-secondary', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-secondary',
-              angle: 180,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('portrait');
-      });
-
-      it('should return landscape when screen.orientation.type is landscape-primary', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'landscape-primary',
-              angle: 0,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('landscape');
-      });
-
-      it('should return landscape when screen.orientation.type is landscape-secondary', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'landscape-secondary',
-              angle: 270,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('landscape');
-      });
-
-      it('should fallback to dimension comparison when screen.orientation not available', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow({ innerWidth: 375, innerHeight: 812 }),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({ orientation: undefined }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('portrait');
-      });
-
-      it('should return landscape when width > height (fallback)', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow({ innerWidth: 1920, innerHeight: 1080 }),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({ orientation: undefined }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientation()).toBe('landscape');
-      });
-    });
-
-    describe('orientationAngle', () => {
-      it('should return angle from screen.orientation', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'landscape-primary',
-              angle: 90,
-              addEventListener: vi.fn(),
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientationAngle()).toBe(90);
-      });
-
-      it('should return 0 when no orientation info available', () => {
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({ orientation: undefined }),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-
-        expect(DeviceInfo.orientationAngle()).toBe(0);
-      });
-    });
-
     describe('onOrientationChange', () => {
-      it('should add event listener to screen.orientation', () => {
+      it('should add a change listener to screen.orientation', () => {
         const addEventListener = vi.fn();
         const removeEventListener = vi.fn();
 
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
         Object.defineProperty(globalThis, 'screen', {
           value: createMockScreen({
             orientation: {
@@ -1490,19 +1275,7 @@ describe('DeviceInfo', () => {
         expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
       });
 
-      it('should fallback to resize event when screen.orientation not available', () => {
-        const addEventListener = vi.fn();
-        const removeEventListener = vi.fn();
-
-        Object.defineProperty(globalThis, 'window', {
-          value: {
-            ...createMockWindow(),
-            addEventListener,
-            removeEventListener,
-          },
-          writable: true,
-          configurable: true,
-        });
+      it('should return a no-op cleanup when not supported', () => {
         Object.defineProperty(globalThis, 'screen', {
           value: createMockScreen({ orientation: undefined }),
           writable: true,
@@ -1512,35 +1285,31 @@ describe('DeviceInfo', () => {
         const handler = vi.fn();
         const cleanup = DeviceInfo.onOrientationChange(handler);
 
-        expect(addEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
-
-        cleanup();
-
-        expect(removeEventListener).toHaveBeenCalledWith('resize', expect.any(Function));
+        expect(typeof cleanup).toBe('function');
+        cleanup(); // Should not throw
+        expect(handler).not.toHaveBeenCalled();
       });
 
-      it('should call handler when orientation changes', () => {
+      it('should call handler with the new state on change', () => {
         let capturedHandler: (() => void) | undefined;
         const addEventListener = vi.fn((_event, handler) => {
           capturedHandler = handler as () => void;
         });
 
-        let currentOrientationType = 'portrait-primary';
+        let currentType = 'portrait-primary';
+        let currentAngle = 0;
 
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow({ innerWidth: 375, innerHeight: 812 }),
-          writable: true,
-          configurable: true,
-        });
         Object.defineProperty(globalThis, 'screen', {
           value: {
             ...createMockScreen(),
             get orientation() {
               return {
                 get type() {
-                  return currentOrientationType;
+                  return currentType;
                 },
-                angle: 0,
+                get angle() {
+                  return currentAngle;
+                },
                 addEventListener,
                 removeEventListener: vi.fn(),
               };
@@ -1553,47 +1322,19 @@ describe('DeviceInfo', () => {
         const handler = vi.fn();
         DeviceInfo.onOrientationChange(handler);
 
-        // Initially portrait, no change yet
+        // No call until the native change event fires
         expect(handler).not.toHaveBeenCalled();
 
-        // Simulate orientation change
-        currentOrientationType = 'landscape-primary';
+        // Simulate a native orientation change
+        currentType = 'landscape-primary';
+        currentAngle = 90;
         capturedHandler?.();
 
-        expect(handler).toHaveBeenCalledWith('landscape');
-      });
-
-      it('should not call handler when orientation stays the same', () => {
-        let capturedHandler: (() => void) | undefined;
-        const addEventListener = vi.fn((_event, handler) => {
-          capturedHandler = handler as () => void;
+        expect(handler).toHaveBeenCalledWith({
+          type: 'landscape-primary',
+          angle: 90,
+          orientation: 'landscape',
         });
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-primary',
-              angle: 0,
-              addEventListener,
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        DeviceInfo.onOrientationChange(handler);
-
-        // Trigger event without actual orientation change
-        capturedHandler?.();
-
-        expect(handler).not.toHaveBeenCalled();
       });
     });
 
@@ -1686,217 +1427,6 @@ describe('DeviceInfo', () => {
           await DeviceInfo.lockOrientation(orientation);
           expect(lock).toHaveBeenCalledWith(orientation);
         }
-      });
-    });
-
-    describe('onOrientationTypeChange', () => {
-      it('should add event listener to screen.orientation', () => {
-        const addEventListener = vi.fn();
-        const removeEventListener = vi.fn();
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-primary',
-              angle: 0,
-              addEventListener,
-              removeEventListener,
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        const cleanup = DeviceInfo.onOrientationTypeChange(handler);
-
-        expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
-
-        cleanup();
-
-        expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
-      });
-
-      it('should return no-op cleanup when screen.orientation not available', () => {
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({ orientation: undefined }),
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        const cleanup = DeviceInfo.onOrientationTypeChange(handler);
-
-        expect(typeof cleanup).toBe('function');
-        cleanup(); // Should not throw
-        expect(handler).not.toHaveBeenCalled();
-      });
-
-      it('should call handler with full OrientationType when orientation changes', () => {
-        let capturedHandler: (() => void) | undefined;
-        const addEventListener = vi.fn((_event, handler) => {
-          capturedHandler = handler as () => void;
-        });
-
-        let currentOrientationType = 'portrait-primary';
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow({ innerWidth: 375, innerHeight: 812 }),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: {
-            ...createMockScreen(),
-            get orientation() {
-              return {
-                get type() {
-                  return currentOrientationType;
-                },
-                angle: 0,
-                addEventListener,
-                removeEventListener: vi.fn(),
-              };
-            },
-          },
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        DeviceInfo.onOrientationTypeChange(handler);
-
-        // Initially portrait-primary, no change yet
-        expect(handler).not.toHaveBeenCalled();
-
-        // Simulate orientation change to landscape-primary
-        currentOrientationType = 'landscape-primary';
-        capturedHandler?.();
-
-        expect(handler).toHaveBeenCalledWith('landscape-primary');
-      });
-
-      it('should call handler with portrait-secondary', () => {
-        let capturedHandler: (() => void) | undefined;
-        const addEventListener = vi.fn((_event, handler) => {
-          capturedHandler = handler as () => void;
-        });
-
-        let currentOrientationType = 'portrait-primary';
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: {
-            ...createMockScreen(),
-            get orientation() {
-              return {
-                get type() {
-                  return currentOrientationType;
-                },
-                angle: 0,
-                addEventListener,
-                removeEventListener: vi.fn(),
-              };
-            },
-          },
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        DeviceInfo.onOrientationTypeChange(handler);
-
-        currentOrientationType = 'portrait-secondary';
-        capturedHandler?.();
-
-        expect(handler).toHaveBeenCalledWith('portrait-secondary');
-      });
-
-      it('should call handler with landscape-secondary', () => {
-        let capturedHandler: (() => void) | undefined;
-        const addEventListener = vi.fn((_event, handler) => {
-          capturedHandler = handler as () => void;
-        });
-
-        let currentOrientationType = 'portrait-primary';
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: {
-            ...createMockScreen(),
-            get orientation() {
-              return {
-                get type() {
-                  return currentOrientationType;
-                },
-                angle: 0,
-                addEventListener,
-                removeEventListener: vi.fn(),
-              };
-            },
-          },
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        DeviceInfo.onOrientationTypeChange(handler);
-
-        currentOrientationType = 'landscape-secondary';
-        capturedHandler?.();
-
-        expect(handler).toHaveBeenCalledWith('landscape-secondary');
-      });
-
-      it('should not call handler when orientation type stays the same', () => {
-        let capturedHandler: (() => void) | undefined;
-        const addEventListener = vi.fn((_event, handler) => {
-          capturedHandler = handler as () => void;
-        });
-
-        Object.defineProperty(globalThis, 'window', {
-          value: createMockWindow(),
-          writable: true,
-          configurable: true,
-        });
-        Object.defineProperty(globalThis, 'screen', {
-          value: createMockScreen({
-            orientation: {
-              type: 'portrait-primary',
-              angle: 0,
-              addEventListener,
-              removeEventListener: vi.fn(),
-            } as unknown as ScreenOrientation,
-          }),
-          writable: true,
-          configurable: true,
-        });
-
-        const handler = vi.fn();
-        DeviceInfo.onOrientationTypeChange(handler);
-
-        // Trigger event without actual orientation change
-        capturedHandler?.();
-
-        expect(handler).not.toHaveBeenCalled();
       });
     });
 
@@ -2132,6 +1662,17 @@ describe('DeviceInfo', () => {
         'landscape-secondary',
       ];
       expect(lockTypes).toHaveLength(8);
+    });
+
+    it('should export OrientationState interface', () => {
+      const state: OrientationState = {
+        type: 'portrait-primary',
+        angle: 0,
+        orientation: 'portrait',
+      };
+      expect(state.type).toBe('portrait-primary');
+      expect(state.angle).toBe(0);
+      expect(state.orientation).toBe('portrait');
     });
 
     it('should export Size interface', () => {


### PR DESCRIPTION
## Summary

Closes #125. Redesigns the `DeviceInfo` orientation sub-API into one immutable, fully-typed `OrientationState` — a single getter and a single listener that share the same shape. Aligns with the library's principles: modern/consistent API, `readonly` immutability, strict type-safety, modern-browser-only.

```ts
interface OrientationState {
  readonly type: OrientationType;     // 'portrait-primary' | 'landscape-primary' | …
  readonly angle: number;             // 0 | 90 | 180 | 270
  readonly orientation: Orientation;  // 'portrait' | 'landscape' (derived convenience)
}
```

## Breaking changes

- `getOrientation()` now returns `OrientationState | undefined` (was `OrientationType | undefined`)
- `onOrientationChange()` now passes `OrientationState` (was `'portrait' | 'landscape'`)
- **Removed** (subsumed): `orientation()`, `orientationAngle()`, `onOrientationTypeChange()`
- Dropped the `window.resize` fallback — built purely on the [Screen Orientation API](https://developer.mozilla.org/docs/Web/API/Screen_Orientation_API) (baseline: Safari/iOS 16.4+). Unsupported → `undefined` getter / no-op listener
- Removed the `@deprecated` tag

`isOrientationSupported()`, `lockOrientation()`, `unlockOrientation()` are unchanged.

## Design notes

- **Snapshot vs. changes**: `getOrientation()` is a pure snapshot; `onOrientationChange()` fires on changes only (no immediate-fire on subscribe). Use the getter for the initial state.
- **No suppressions**: by routing every guard through `isOrientationSupported()`, all the former per-method `eslint-disable` comments were removed — only the unavoidable one inside the guard itself remains.

## Docs & migration

- `documentation/device.md` rewritten (API table, `OrientationState` type, usage examples). Also fixes a pre-existing doc bug — `lockOrientation` was documented as `Promise<boolean>` but has returned `Promise<void>`.
- `MIGRATION.md` gains an "Orientation API" before/after section with a removed→replacement table.
- `examples/device-info.ts` migrated (two orientation monitors merged into one).

## Quality gates

`format:check` · `lint` (`--max-warnings=0`) · `typecheck` · **4242 tests** · coverage 100% lines / 97.23% branch (>95) · `build` · `lint:package` (publint + attw) · `size:check` — all green.

Net **−384 lines**.

> Note: a follow-up PR will extract `defineGlobal()`/`mockOrientation()` test helpers to remove the file-wide `Object.defineProperty(globalThis, …)` duplication (130 call sites) that phpstorm flags — kept separate to keep this breaking-API change reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
