### PR TITLE
ci: load Stryker vitest runner via explicit plugins list

### DIFF
--- a/stryker.config.js
+++ b/stryker.config.js
@@ -2,6 +2,9 @@
 export default {
   mutate: ['src/**/*.ts', '!src/**/index.ts'],
   testRunner: 'vitest',
+  // Explicit plugin list: Stryker 9.6.x auto-discovery fails to find plugins
+  // under pnpm's symlinked node_modules ("no TestRunner plugins were loaded").
+  plugins: ['@stryker-mutator/vitest-runner'],
   checkers: [],
   reporters: ['html', 'clear-text', 'progress'],
   htmlReporter: { fileName: 'reports/mutation/mutation.html' },


### PR DESCRIPTION
## Summary

Fixes the `mutation` CI job, which crashes at startup with:

```
Cannot find TestRunner plugin "vitest". In fact, no TestRunner plugins were loaded.
```

Stryker 9.6.x's plugin **auto-discovery** fails to resolve plugins under pnpm's symlinked `node_modules`, so the vitest runner is never loaded and the job dies before testing a single mutant. Declaring the plugin explicitly in `stryker.config.js` restores loading:

```js
plugins: ['@stryker-mutator/vitest-runner'],
```

## Why it surfaced now

The mutation gate only runs when `src/**` changes. The recent merges (#117, #121, #123, #124) touched tooling/deps but not `src/`, so the job was **skipped** and the 9.6.1 regression stayed hidden until the first src-touching PR (#126).

## Verification

Locally, with the explicit plugin list, Stryker loads the runner, the initial test run passes (4242 tests), and mutation testing proceeds normally. No `src/` or test changes — the mutation gate is skipped on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
