### PR TITLE
docs: track latest Socket score in README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Node.js Version](https://img.shields.io/node/v/@zappzarapp/browser-utils.svg)](https://www.npmjs.com/package/@zappzarapp/browser-utils)
 [![License](https://img.shields.io/npm/l/@zappzarapp/browser-utils.svg)](https://www.npmjs.com/package/@zappzarapp/browser-utils)
 [![CI](https://github.com/marcstraube/zappzarapp-node-browser-utils/actions/workflows/ci.yml/badge.svg)](https://github.com/marcstraube/zappzarapp-node-browser-utils/actions/workflows/ci.yml)
-[![Socket Badge](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils/1.2.0)](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils/1.2.0)
+[![Socket Badge](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils)](https://socket.dev/npm/package/@zappzarapp/browser-utils)
 
 Zero-dependency browser utilities with security-first design — type-safe,
 tree-shakeable, and fully tested.


### PR DESCRIPTION
## Summary

The README Socket badge URL was pinned to `1.2.0`, so it never reflected newer
releases. Drop the version segment so it tracks the latest published version —
matching the npm / Node / License badges, which already auto-update — and point
the link to the Socket package page instead of the raw badge SVG.

```diff
-[![Socket Badge](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils/1.2.0)](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils/1.2.0)
+[![Socket Badge](https://badge.socket.dev/npm/package/@zappzarapp/browser-utils)](https://socket.dev/npm/package/@zappzarapp/browser-utils)
```

Both the version-less badge URL and the package page return `200` (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
