### PR TITLE
docs(color): use American English spelling (normalize, gray)

### DIFF
--- a/documentation/color.md
+++ b/documentation/color.md
@@ -62,11 +62,11 @@ rather than rejected — parsing one returns a `COLOR_UNSUPPORTED_SPACE` error
 (not `COLOR_INVALID_FORMAT`), so a real-but-unsupported color is distinguishable
 from malformed input.
 
-### Normalisation policy
+### Normalization policy
 
 Input is parsed leniently but securely:
 
-- Surrounding/internal whitespace is tolerated; hex case is normalised.
+- Surrounding/internal whitespace is tolerated; hex case is normalized.
 - Out-of-range values are **clamped**: `rgb(256, -1, 300)` → `255, 0, 255`; hue
   `400°` → `40°`; `s 150%` → `100%`; alpha `1.5` → `1`.
 - Mixing `<number>` and `<percentage>` across the three `rgb()` channels is

--- a/src/color/convert.ts
+++ b/src/color/convert.ts
@@ -27,7 +27,7 @@ export interface Hsl {
 }
 
 /**
- * Normalise a hue (in degrees) into the `[0, 360)` range.
+ * Normalize a hue (in degrees) into the `[0, 360)` range.
  *
  * @internal
  */
@@ -54,7 +54,7 @@ export function rgbaToHsl(color: Rgba): Hsl {
   const l = (max + min) / 2;
 
   if (max === min) {
-    // Achromatic (grey): hue and saturation are undefined → 0.
+    // Achromatic (gray): hue and saturation are undefined → 0.
     return { h: 0, s: 0, l: l * 100, a: color.a };
   }
 
@@ -100,7 +100,7 @@ function hue2rgb(p: number, q: number, t: number): number {
 /**
  * Convert an {@link Hsl} color to the canonical {@link Rgba} hub.
  *
- * Out-of-range inputs are normalised: hue wraps into `[0, 360)`, saturation and
+ * Out-of-range inputs are normalized: hue wraps into `[0, 360)`, saturation and
  * lightness clamp to `0–100`.
  *
  * @param hsl Source HSL color.
@@ -112,8 +112,8 @@ export function hslToRgba(hsl: Hsl): Rgba {
   const l = Math.min(100, Math.max(0, hsl.l)) / 100;
 
   if (s === 0) {
-    const grey = l * 255;
-    return makeRgba(grey, grey, grey, hsl.a);
+    const gray = l * 255;
+    return makeRgba(gray, gray, gray, hsl.a);
   }
 
   const q = l < 0.5 ? l * (1 + s) : l + s - l * s;

--- a/src/color/parse.ts
+++ b/src/color/parse.ts
@@ -7,7 +7,7 @@
  * produces the canonical {@link Rgba} hub.
  *
  * Security: input is length-bounded and matched with linear, non-backtracking
- * regexes; out-of-range channels are normalised (clamped), and raw input is
+ * regexes; out-of-range channels are normalized (clamped), and raw input is
  * never reflected in error messages (see {@link ColorError}).
  *
  * @example
@@ -264,7 +264,7 @@ function parseRgbFunction(args: string): Result<Rgba, ColorError> {
 
 function parseHueToken(token: string): number | null {
   // parseFloat reads the leading number and ignores any "deg" suffix; the range
-  // is normalised later by normalizeHue.
+  // is normalized later by normalizeHue.
   return HUE_TOKEN_RE.test(token) ? parseFloat(token) : null;
 }
 


### PR DESCRIPTION
Aligns the `color` module's comments and documentation with the codebase's American spelling convention (normalise → normalize, grey → gray). Comments and docs only — no behavior change.
