### PR TITLE
feat(request): add head() and options() convenience methods

### DIFF
--- a/documentation/request.md
+++ b/documentation/request.md
@@ -129,7 +129,7 @@ const response = await api.fetch('/users', {
 });
 ```
 
-#### get(), post(), put(), patch(), delete()
+#### get(), post(), put(), patch(), delete(), head(), options()
 
 Convenience methods for HTTP verbs.
 
@@ -148,6 +148,12 @@ await api.patch('/users/1', JSON.stringify({ active: true }));
 
 // DELETE request
 await api.delete('/users/1');
+
+// HEAD request (headers only, no body)
+const meta = await api.head('/users/1');
+
+// OPTIONS request (e.g. CORS preflight inspection)
+const allowed = await api.options('/users');
 ```
 
 #### use()

--- a/src/request/RequestInterceptor.ts
+++ b/src/request/RequestInterceptor.ts
@@ -368,6 +368,12 @@ export interface RequestInterceptorInstance {
   /** Make a DELETE request */
   delete(url: string, options?: Omit<RequestInit, 'method'>): Promise<Response>;
 
+  /** Make a HEAD request */
+  head(url: string, options?: Omit<RequestInit, 'method'>): Promise<Response>;
+
+  /** Make an OPTIONS request */
+  options(url: string, options?: Omit<RequestInit, 'method'>): Promise<Response>;
+
   /** Add middleware */
   use(middleware: RequestMiddleware): CleanupFn;
 
@@ -793,6 +799,14 @@ export const RequestInterceptor = {
 
       delete(url: string, options?: Omit<RequestInit, 'method'>): Promise<Response> {
         return executeFetch(url, { ...options, method: 'DELETE' });
+      },
+
+      head(url: string, options?: Omit<RequestInit, 'method'>): Promise<Response> {
+        return executeFetch(url, { ...options, method: 'HEAD' });
+      },
+
+      options(url: string, init?: Omit<RequestInit, 'method'>): Promise<Response> {
+        return executeFetch(url, { ...init, method: 'OPTIONS' });
       },
 
       use(middleware: RequestMiddleware): CleanupFn {

--- a/tests/request/RequestInterceptor.test.ts
+++ b/tests/request/RequestInterceptor.test.ts
@@ -474,6 +474,60 @@ describe('RequestInterceptor', () => {
 
         api.destroy();
       });
+
+      it('should make HEAD request', async () => {
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+        });
+
+        await api.head('/users');
+
+        const init = getLastFetchInit(mockFetch);
+        expect(init.method).toBe('HEAD');
+
+        api.destroy();
+      });
+
+      it('should make OPTIONS request', async () => {
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+        });
+
+        await api.options('/users');
+
+        const init = getLastFetchInit(mockFetch);
+        expect(init.method).toBe('OPTIONS');
+
+        api.destroy();
+      });
+
+      it('should forward options to HEAD request', async () => {
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+        });
+
+        await api.head('/users', { headers: { 'X-Custom': 'value' } });
+
+        const init = getLastFetchInit(mockFetch);
+        expect(init.method).toBe('HEAD');
+        expect(init.headers.get('X-Custom')).toBe('value');
+
+        api.destroy();
+      });
+
+      it('should forward options to OPTIONS request', async () => {
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+        });
+
+        await api.options('/users', { headers: { 'X-Custom': 'value' } });
+
+        const init = getLastFetchInit(mockFetch);
+        expect(init.method).toBe('OPTIONS');
+        expect(init.headers.get('X-Custom')).toBe('value');
+
+        api.destroy();
+      });
     });
 
     describe('authentication', () => {


### PR DESCRIPTION
## Summary

Adds `head()` and `options()` convenience wrappers to `RequestInterceptor`,
mirroring the existing body-less `get()`/`delete()` signatures. `HEAD` and
`OPTIONS` were already part of the `HttpMethod` type — only the instance
helpers were missing.

## Changes

- `src/request/RequestInterceptor.ts` — `head()` + `options()` on the
  interface and implementation
- `tests/request/RequestInterceptor.test.ts` — 4 tests (method + options
  forwarding for both verbs)
- `documentation/request.md` — convenience-method section extended

## Quality

`pnpm run quality` passes: Prettier, ESLint (`--max-warnings=0`), 144 request
tests, coverage thresholds, build + size-limits, audit.

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)