### PR TITLE
feat(form): add async loading state, field-change and submit handlers

### DIFF
--- a/documentation/form.md
+++ b/documentation/form.md
@@ -70,35 +70,42 @@ const validator = FormValidator.create({
 
 ### Validation Methods
 
-| Method                           | Returns                 | Description           |
-| -------------------------------- | ----------------------- | --------------------- |
-| `validate(form)`                 | `ValidationResult`      | Validate entire form  |
-| `validateField(form, fieldName)` | `FieldValidationResult` | Validate single field |
+| Method                             | Returns                          | Description                                |
+| ---------------------------------- | -------------------------------- | ------------------------------------------ |
+| `validate(form)`                   | `ValidationResult`               | Validate entire form (sync rules)          |
+| `validateField(form, fieldName)`   | `FieldValidationResult`          | Validate single field (sync rules)         |
+| `validateFieldAsync(field, opts?)` | `Promise<FieldValidationResult>` | Validate a field including its async rule  |
+| `validateFormAsync(form)`          | `Promise<ValidationResult>`      | Validate entire form including async rules |
+| `isValidating(fieldName)`          | `boolean`                        | Whether async validation is in flight      |
 
 ### Event Methods
 
-| Method                                   | Returns     | Description                       |
-| ---------------------------------------- | ----------- | --------------------------------- |
-| `onSubmit(form, handler)`                | `CleanupFn` | Attach validation to submit event |
-| `onFieldChange(form, handler, options?)` | `CleanupFn` | Attach real-time field validation |
+| Method                                        | Returns     | Description                             |
+| --------------------------------------------- | ----------- | --------------------------------------- |
+| `onSubmit(form, handler)`                     | `CleanupFn` | Attach validation to submit event       |
+| `onSubmitAsync(form, handler, options?)`      | `CleanupFn` | Attach async validation to submit event |
+| `onFieldChange(form, handler, options?)`      | `CleanupFn` | Attach real-time field validation       |
+| `onFieldChangeAsync(form, handler, options?)` | `CleanupFn` | Attach real-time async field validation |
 
 ### Validation Rules
 
-| Rule        | Type                     | Description                      |
-| ----------- | ------------------------ | -------------------------------- |
-| `required`  | `boolean`                | Field must not be empty          |
-| `minLength` | `number`                 | Minimum string length            |
-| `maxLength` | `number`                 | Maximum string length            |
-| `min`       | `number`                 | Minimum numeric value            |
-| `max`       | `number`                 | Maximum numeric value            |
-| `email`     | `boolean`                | Must be valid email format       |
-| `url`       | `boolean`                | Must be valid URL                |
-| `number`    | `boolean`                | Must be numeric                  |
-| `integer`   | `boolean`                | Must be integer                  |
-| `pattern`   | `RegExp`                 | Must match pattern               |
-| `matches`   | `string`                 | Must match another field's value |
-| `custom`    | `CustomValidator`        | Custom validation function       |
-| `messages`  | `Record<string, string>` | Custom error messages            |
+| Rule              | Type                     | Description                           |
+| ----------------- | ------------------------ | ------------------------------------- |
+| `required`        | `boolean`                | Field must not be empty               |
+| `minLength`       | `number`                 | Minimum string length                 |
+| `maxLength`       | `number`                 | Maximum string length                 |
+| `min`             | `number`                 | Minimum numeric value                 |
+| `max`             | `number`                 | Maximum numeric value                 |
+| `email`           | `boolean`                | Must be valid email format            |
+| `url`             | `boolean`                | Must be valid URL                     |
+| `number`          | `boolean`                | Must be numeric                       |
+| `integer`         | `boolean`                | Must be integer                       |
+| `pattern`         | `RegExp`                 | Must match pattern                    |
+| `matches`         | `string`                 | Must match another field's value      |
+| `custom`          | `CustomValidator`        | Custom validation function            |
+| `asyncCustom`     | `AsyncValidator`         | Async validation function             |
+| `asyncDebounceMs` | `number`                 | Debounce for async rule (default 300) |
+| `messages`        | `Record<string, string>` | Custom error messages                 |
 
 ### Types
 
@@ -107,6 +114,13 @@ type CustomValidator = (
   value: string,
   form: HTMLFormElement
 ) => boolean | string;
+
+// Returns null when valid, or an error message string when invalid.
+type AsyncValidator = (
+  value: string,
+  field: string,
+  form: HTMLFormElement
+) => Promise<string | null>;
 
 interface FieldRules {
   readonly required?: boolean;
@@ -121,6 +135,8 @@ interface FieldRules {
   readonly pattern?: RegExp;
   readonly matches?: string;
   readonly custom?: CustomValidator;
+  readonly asyncCustom?: AsyncValidator;
+  readonly asyncDebounceMs?: number;
   readonly messages?: Partial<Record<keyof FieldRules, string>>;
 }
 
@@ -224,6 +240,98 @@ const cleanup = validator.onFieldChange(
   { validateOn: 'blur' }
 );
 ```
+
+### Async Validation
+
+Async rules (`asyncCustom`) cover checks that need a server round-trip, such as
+username availability or email uniqueness. An async validator returns `null`
+when valid or an error message string when invalid.
+
+```typescript
+const validator = FormValidator.create({
+  username: {
+    required: true,
+    minLength: 3,
+    asyncCustom: async (value) => {
+      const res = await fetch(
+        `/api/username-available?u=${encodeURIComponent(value)}`
+      );
+      const { available } = await res.json();
+      return available ? null : 'Username is already taken';
+    },
+    asyncDebounceMs: 400, // optional, defaults to 300
+  },
+});
+```
+
+The async validator runs **only when the field's synchronous rules pass**. A
+value that is too short or malformed short-circuits before the async validator
+is invoked, so no lookup is issued for an already-invalid value. Set the
+threshold via the usual sync rules — e.g. `minLength: 3` means the availability
+check fires only from the third character on. Combined with the built-in
+debounce, this keeps backend load minimal.
+
+`onFieldChangeAsync` wires this up to live input. It defaults to the `input`
+event and exposes `onValidationStart` / `onValidationEnd` callbacks to drive a
+per-field loading indicator; `isValidating(fieldName)` can be polled for the
+same state. The callbacks fire once per validation cycle even when rapid typing
+collapses several keystrokes into one debounced run.
+
+```typescript
+const cleanup = validator.onFieldChangeAsync(
+  form,
+  (fieldName, result) => {
+    const errorElement = form.querySelector(`[data-error="${fieldName}"]`);
+    if (errorElement) {
+      errorElement.textContent = result.firstError ?? '';
+    }
+  },
+  {
+    onValidationStart: (fieldName) => toggleSpinner(fieldName, true),
+    onValidationEnd: (fieldName) => toggleSpinner(fieldName, false),
+  }
+);
+
+// Validate the whole form (including async rules) before submit:
+const result = await validator.validateFormAsync(form);
+if (result.valid) {
+  // ...
+}
+```
+
+For submit handling, `onSubmitAsync` validates the whole form (including async
+rules) before the handler runs. Unlike the synchronous `onSubmit` — which lets a
+valid form submit natively — `onSubmitAsync` **always** prevents the native
+submit (the result is only known after an await), so the handler is responsible
+for sending on success. The handler always runs and receives the result; check
+`result.valid` to branch. Concurrent submits are ignored while a cycle is in
+flight, so a double click cannot trigger overlapping submissions.
+
+```typescript
+const cleanup = validator.onSubmitAsync(
+  form,
+  async (data, result) => {
+    if (!result.valid) {
+      showErrors(result.errors);
+      FormUtils.focusFirstInvalid(form);
+      return;
+    }
+    await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  },
+  {
+    onValidationStart: () => FormUtils.disable(form),
+    onValidationEnd: () => FormUtils.enable(form),
+  }
+);
+```
+
+> **Security:** Async validators are UX, not an authority. A client-side
+> availability/uniqueness check cannot close the time-of-check/time-of-use gap —
+> enforce uniqueness server-side (e.g. a `UNIQUE` constraint) regardless.
 
 ### Form Serialization
 

--- a/src/form/FormValidator.ts
+++ b/src/form/FormValidator.ts
@@ -736,6 +736,20 @@ export class FormValidator {
     return validator(value, fieldName, form);
   }
 
+  /**
+   * Check whether async validation is currently in flight for a field.
+   *
+   * Returns true while the field's async validator is debouncing or its
+   * promise is still pending — useful for driving a per-field loading
+   * indicator. Always false for fields without a pending async validation.
+   *
+   * @param fieldName - The field name to check
+   * @returns Whether async validation is in flight for the field
+   */
+  isValidating(fieldName: string): boolean {
+    return this.debounceTimers.has(fieldName) || this.pendingValidations.has(fieldName);
+  }
+
   // =========================================================================
   // Event Handling
   // =========================================================================
@@ -758,6 +772,73 @@ export class FormValidator {
       }
 
       handler(data, result);
+    };
+
+    form.addEventListener('submit', submitHandler);
+
+    return (): void => {
+      form.removeEventListener('submit', submitHandler);
+    };
+  }
+
+  /**
+   * Attach async validation to the form submit event.
+   *
+   * Like {@link onSubmit}, but validates with {@link validateFormAsync} (sync
+   * rules plus async validators). Because the result is only known after an
+   * await, the native submit is **always** prevented — the handler is
+   * responsible for submitting on success (e.g. `fetch` or `form.submit()`).
+   *
+   * The handler always runs and receives the validation result; check
+   * `result.valid` to branch (consistent with {@link onSubmit}). Concurrent
+   * submits are ignored while a validation/handler cycle is in flight, so a
+   * double click or repeated Enter cannot trigger overlapping submissions.
+   *
+   * Note: async validators are UX, not an authority. Uniqueness and similar
+   * invariants must still be enforced server-side; a client check cannot close
+   * the time-of-check/time-of-use gap.
+   *
+   * @param form - The form element to attach to
+   * @param handler - Called with the form data and validation result
+   * @param options - Optional configuration
+   * @param options.onValidationStart - Called when async validation begins
+   * @param options.onValidationEnd - Called when async validation completes
+   * @returns Cleanup function
+   */
+  onSubmitAsync(
+    form: HTMLFormElement,
+    handler: (data: Record<string, unknown>, result: ValidationResult) => void | Promise<void>,
+    options?: {
+      onValidationStart?: () => void;
+      onValidationEnd?: () => void;
+    }
+  ): CleanupFn {
+    const { onValidationStart, onValidationEnd } = options ?? {};
+    let submitting = false;
+
+    const submitHandler = (event: SubmitEvent): void => {
+      // The result is only known asynchronously, so the native submit can
+      // never proceed: always prevent it and let the handler submit on success.
+      event.preventDefault();
+
+      // Ignore concurrent submits while a cycle is in flight.
+      if (submitting) {
+        return;
+      }
+      submitting = true;
+
+      onValidationStart?.();
+
+      void (async (): Promise<void> => {
+        try {
+          const result = await this.validateFormAsync(form);
+          onValidationEnd?.();
+          const data = FormSerializer.toObject(form);
+          await handler(data, result);
+        } finally {
+          submitting = false;
+        }
+      })();
     };
 
     form.addEventListener('submit', submitHandler);
@@ -794,6 +875,88 @@ export class FormValidator {
           handler(fieldName, result);
         }
       }
+    };
+
+    form.addEventListener(validateOn, fieldHandler);
+
+    return () => {
+      form.removeEventListener(validateOn, fieldHandler);
+    };
+  }
+
+  /**
+   * Attach real-time async validation to form fields.
+   *
+   * Like {@link onFieldChange}, but runs {@link validateFieldAsync} (synchronous
+   * rules plus the debounced async validator). Defaults to the `input` event,
+   * since async validation is most useful while typing.
+   *
+   * The optional `onValidationStart` / `onValidationEnd` callbacks bracket the
+   * in-flight async work to drive a per-field loading indicator. They fire at
+   * most once per validation cycle: when rapid input collapses several events
+   * into one debounced run, `onValidationStart` fires once and only the final,
+   * non-superseded run fires `onValidationEnd` and invokes `handler`.
+   *
+   * @param form - The form element to attach to
+   * @param handler - Called with the field name and result of each validation
+   * @param options - Optional configuration
+   * @param options.validateOn - Event to validate on (default: 'input')
+   * @param options.onValidationStart - Called when async validation begins for a field
+   * @param options.onValidationEnd - Called when async validation completes for a field
+   * @returns Cleanup function
+   */
+  onFieldChangeAsync(
+    form: HTMLFormElement,
+    handler: (fieldName: string, result: FieldValidationResult) => void,
+    options?: {
+      validateOn?: 'blur' | 'input' | 'change';
+      onValidationStart?: (fieldName: string) => void;
+      onValidationEnd?: (fieldName: string) => void;
+    }
+  ): CleanupFn {
+    const { validateOn = 'input', onValidationStart, onValidationEnd } = options ?? {};
+
+    // Track started-but-not-ended fields (to fire onValidationStart once) and a
+    // per-field sequence so only the latest run reports completion.
+    const inFlight = new Set<string>();
+    const sequence = new Map<string, number>();
+
+    const fieldHandler = (event: Event): void => {
+      const target = event.target;
+
+      if (
+        !(
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLSelectElement ||
+          target instanceof HTMLTextAreaElement
+        )
+      ) {
+        return;
+      }
+
+      const fieldName = target.name;
+      if (!fieldName || !(fieldName in this.rules)) {
+        return;
+      }
+
+      const runId = (sequence.get(fieldName) ?? 0) + 1;
+      sequence.set(fieldName, runId);
+
+      if (!inFlight.has(fieldName)) {
+        inFlight.add(fieldName);
+        onValidationStart?.(fieldName);
+      }
+
+      void this.validateFieldAsync(target).then((result) => {
+        // Ignore superseded runs: a newer event has started since this one,
+        // so let that later run report completion instead.
+        if (sequence.get(fieldName) !== runId) {
+          return;
+        }
+        inFlight.delete(fieldName);
+        onValidationEnd?.(fieldName);
+        handler(fieldName, result);
+      });
     };
 
     form.addEventListener(validateOn, fieldHandler);

--- a/tests/form/FormValidator.test.ts
+++ b/tests/form/FormValidator.test.ts
@@ -980,6 +980,134 @@ describe('FormValidator', () => {
   });
 
   // ===========================================================================
+  // onSubmitAsync
+  // ===========================================================================
+
+  describe('onSubmitAsync', () => {
+    // validateFormAsync uses no debounce timers, so real timers suffice; this
+    // flushes the pending microtask chain (validation + handler).
+    const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+    const submitEvent = (): Event => new Event('submit', { bubbles: true, cancelable: true });
+
+    it('should always prevent the native submit, even when valid', () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const validator = FormValidator.create({
+        username: { asyncCustom: vi.fn().mockResolvedValue(null) },
+      });
+      validator.onSubmitAsync(form, vi.fn());
+
+      const event = submitEvent();
+      form.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('should call handler with data and a valid result', async () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const asyncValidator = vi.fn().mockResolvedValue(null);
+      const validator = FormValidator.create({ username: { asyncCustom: asyncValidator } });
+
+      const handler = vi.fn();
+      validator.onSubmitAsync(form, handler);
+
+      form.dispatchEvent(submitEvent());
+      await flush();
+
+      expect(asyncValidator).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledWith(
+        { username: 'abcd' },
+        expect.objectContaining({ valid: true })
+      );
+    });
+
+    it('should call handler with an invalid result on failure', async () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const validator = FormValidator.create({
+        username: { asyncCustom: vi.fn().mockResolvedValue('Taken') },
+      });
+
+      const handler = vi.fn();
+      validator.onSubmitAsync(form, handler);
+
+      form.dispatchEvent(submitEvent());
+      await flush();
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ valid: false, firstError: 'Taken' })
+      );
+    });
+
+    it('should fire onValidationStart and onValidationEnd', async () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const validator = FormValidator.create({
+        username: { asyncCustom: vi.fn().mockResolvedValue(null) },
+      });
+
+      const onValidationStart = vi.fn();
+      const onValidationEnd = vi.fn();
+      validator.onSubmitAsync(form, vi.fn(), { onValidationStart, onValidationEnd });
+
+      form.dispatchEvent(submitEvent());
+      expect(onValidationStart).toHaveBeenCalledTimes(1);
+
+      await flush();
+      expect(onValidationEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore concurrent submits while validating', async () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const asyncValidator = vi.fn().mockResolvedValue(null);
+      const validator = FormValidator.create({ username: { asyncCustom: asyncValidator } });
+
+      const handler = vi.fn();
+      validator.onSubmitAsync(form, handler);
+
+      form.dispatchEvent(submitEvent());
+      form.dispatchEvent(submitEvent());
+      await flush();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(asyncValidator).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep blocking submits until an async handler settles', async () => {
+      addInput(form, 'text', 'username', 'abcd');
+      const validator = FormValidator.create({
+        username: { asyncCustom: vi.fn().mockResolvedValue(null) },
+      });
+
+      let release!: () => void;
+      const handler = vi.fn(() => new Promise<void>((resolve) => (release = resolve)));
+      validator.onSubmitAsync(form, handler);
+
+      form.dispatchEvent(submitEvent());
+      await flush();
+      // Handler is in flight; a second submit must be ignored.
+      form.dispatchEvent(submitEvent());
+      await flush();
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      release();
+      await flush();
+      // Now a fresh submit is allowed again.
+      form.dispatchEvent(submitEvent());
+      await flush();
+      expect(handler).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return a cleanup function', () => {
+      const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+      const removeEventListenerSpy = vi.spyOn(form, 'removeEventListener');
+
+      const cleanup = validator.onSubmitAsync(form, vi.fn());
+      cleanup();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('submit', expect.any(Function));
+    });
+  });
+
+  // ===========================================================================
   // onFieldChange
   // ===========================================================================
 
@@ -1849,6 +1977,169 @@ describe('FormValidator', () => {
         const result = await resultPromise;
 
         expect(result.valid).toBe(true);
+      });
+    });
+
+    describe('isValidating', () => {
+      it('should return false when no validation is in flight', () => {
+        const validator = FormValidator.create({
+          username: { asyncCustom: vi.fn().mockResolvedValue(null) },
+        });
+
+        expect(validator.isValidating('username')).toBe(false);
+      });
+
+      it('should return false for a field without a pending async validation', () => {
+        const validator = FormValidator.create({ username: { required: true } });
+
+        expect(validator.isValidating('username')).toBe(false);
+        expect(validator.isValidating('unknown')).toBe(false);
+      });
+
+      it('should be true while debouncing and false once resolved', async () => {
+        const input = addInput(form, 'text', 'username', 'abcd');
+        const validator = FormValidator.create({
+          username: { asyncCustom: vi.fn().mockResolvedValue(null) },
+        });
+
+        const resultPromise = validator.validateFieldAsync(input);
+        expect(validator.isValidating('username')).toBe(true);
+
+        await vi.runAllTimersAsync();
+        await resultPromise;
+
+        expect(validator.isValidating('username')).toBe(false);
+      });
+    });
+
+    describe('onFieldChangeAsync', () => {
+      it('should attach with the default input event', () => {
+        const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+        const addEventListenerSpy = vi.spyOn(form, 'addEventListener');
+
+        validator.onFieldChangeAsync(form, vi.fn());
+
+        expect(addEventListenerSpy).toHaveBeenCalledWith('input', expect.any(Function));
+      });
+
+      it('should attach with a custom validateOn event', () => {
+        const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+        const addEventListenerSpy = vi.spyOn(form, 'addEventListener');
+
+        validator.onFieldChangeAsync(form, vi.fn(), { validateOn: 'blur' });
+
+        expect(addEventListenerSpy).toHaveBeenCalledWith('blur', expect.any(Function));
+      });
+
+      it('should return a cleanup function', () => {
+        const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+        const removeEventListenerSpy = vi.spyOn(form, 'removeEventListener');
+
+        const cleanup = validator.onFieldChangeAsync(form, vi.fn());
+        cleanup();
+
+        expect(removeEventListenerSpy).toHaveBeenCalledWith('input', expect.any(Function));
+      });
+
+      it('should call handler with async result and fire loading callbacks', async () => {
+        const input = addInput(form, 'text', 'username', 'abcd');
+        const asyncValidator = vi.fn().mockResolvedValue('Username taken');
+        const validator = FormValidator.create({ username: { asyncCustom: asyncValidator } });
+
+        const handler = vi.fn();
+        const onValidationStart = vi.fn();
+        const onValidationEnd = vi.fn();
+        validator.onFieldChangeAsync(form, handler, { onValidationStart, onValidationEnd });
+
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        // Start fires synchronously, before the debounce/await.
+        expect(onValidationStart).toHaveBeenCalledWith('username');
+
+        await vi.runAllTimersAsync();
+
+        expect(onValidationEnd).toHaveBeenCalledWith('username');
+        expect(handler).toHaveBeenCalledWith(
+          'username',
+          expect.objectContaining({ valid: false, firstError: 'Username taken' })
+        );
+      });
+
+      it('should ignore events for fields without rules', async () => {
+        addInput(form, 'text', 'extra', 'value');
+        const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+
+        const handler = vi.fn();
+        const onValidationStart = vi.fn();
+        validator.onFieldChangeAsync(form, handler, { onValidationStart });
+
+        const extra = form.querySelector('input[name="extra"]') as HTMLInputElement;
+        extra.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.runAllTimersAsync();
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(onValidationStart).not.toHaveBeenCalled();
+      });
+
+      it('should ignore events from elements without a name', async () => {
+        const input = document.createElement('input');
+        input.type = 'text';
+        form.appendChild(input);
+        const validator = FormValidator.create({ username: { asyncCustom: vi.fn() } });
+
+        const handler = vi.fn();
+        validator.onFieldChangeAsync(form, handler);
+
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.runAllTimersAsync();
+
+        expect(handler).not.toHaveBeenCalled();
+      });
+
+      it('should fire start and end once across rapid debounced input', async () => {
+        const input = addInput(form, 'text', 'username', 'a');
+        const asyncValidator = vi.fn().mockResolvedValue(null);
+        const validator = FormValidator.create({ username: { asyncCustom: asyncValidator } });
+
+        const handler = vi.fn();
+        const onValidationStart = vi.fn();
+        const onValidationEnd = vi.fn();
+        validator.onFieldChangeAsync(form, handler, { onValidationStart, onValidationEnd });
+
+        // Three rapid input events before the debounce elapses.
+        input.value = 'ab';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.value = 'abc';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        input.value = 'abcd';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+
+        await vi.runAllTimersAsync();
+
+        expect(onValidationStart).toHaveBeenCalledTimes(1);
+        expect(onValidationEnd).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(asyncValidator).toHaveBeenCalledTimes(1);
+        expect(asyncValidator).toHaveBeenCalledWith('abcd', 'username', form);
+      });
+
+      it('should allow a new validation cycle after completion', async () => {
+        const input = addInput(form, 'text', 'username', 'abcd');
+        const asyncValidator = vi.fn().mockResolvedValue(null);
+        const validator = FormValidator.create({ username: { asyncCustom: asyncValidator } });
+
+        const onValidationStart = vi.fn();
+        const onValidationEnd = vi.fn();
+        validator.onFieldChangeAsync(form, vi.fn(), { onValidationStart, onValidationEnd });
+
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.runAllTimersAsync();
+
+        input.value = 'efgh';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        await vi.runAllTimersAsync();
+
+        expect(onValidationStart).toHaveBeenCalledTimes(2);
+        expect(onValidationEnd).toHaveBeenCalledTimes(2);
       });
     });
   });


### PR DESCRIPTION
## Summary

Rounds out the form async-validation API with loading state and async-aware
event handlers, and documents the (previously undocumented) async API.

- `isValidating(field)` — sync getter, true while a field's async validator is
  debouncing or pending; for per-field loading indicators.
- `onFieldChangeAsync(form, handler, options?)` — like `onFieldChange` but runs
  `validateFieldAsync`. Defaults to `input`; `onValidationStart`/`onValidationEnd`
  callbacks fire once per cycle even under rapid debounced input.
- `onSubmitAsync(form, handler, options?)` — like `onSubmit` but validates with
  `validateFormAsync`. Always prevents the native submit (result known only
  after await) — the handler submits on success. Concurrent submits are ignored
  while a cycle is in flight (double-click guard).

## Docs

`documentation/form.md`: async methods in the tables, `asyncCustom`/
`asyncDebounceMs` + `AsyncValidator` type, and a new "Async Validation" section
covering the sync-gate behavior and a security note (client-side async checks
are UX, not server-side enforcement — TOCTOU).

## Quality

`pnpm run quality` passes: 179 tests, 100% coverage, lint, typecheck, build,
size-limits, audit.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)