### PR TITLE
feat(websocket): add SSE/polling transport fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ tree-shakeable, and fully tested.
 
 ### Network & Communication
 
-| Module    | Key Classes                   | Description                      |
-| --------- | ----------------------------- | -------------------------------- |
-| network   | `RetryQueue`, `NetworkStatus` | Retry queue with backoff         |
-| offline   | `OfflineQueue`                | IndexedDB-backed offline sync    |
-| websocket | `WebSocketManager`            | WebSocket with auto-reconnect    |
-| request   | `RequestInterceptor`          | Fetch middleware, auth, progress |
-| url       | `UrlBuilder`                  | URL building, query params       |
-| broadcast | `BroadcastManager`            | Cross-tab messaging              |
+| Module    | Key Classes                   | Description                           |
+| --------- | ----------------------------- | ------------------------------------- |
+| network   | `RetryQueue`, `NetworkStatus` | Retry queue with backoff              |
+| offline   | `OfflineQueue`                | IndexedDB-backed offline sync         |
+| websocket | `WebSocketManager`            | Auto-reconnect + SSE/polling fallback |
+| request   | `RequestInterceptor`          | Fetch middleware, auth, progress      |
+| url       | `UrlBuilder`                  | URL building, query params            |
+| broadcast | `BroadcastManager`            | Cross-tab messaging                   |
 
 ### Device & Environment
 

--- a/documentation/websocket.md
+++ b/documentation/websocket.md
@@ -1,6 +1,7 @@
 # WebSocket Utilities
 
-Type-safe WebSocket wrapper with automatic reconnection and message queuing.
+Type-safe WebSocket wrapper with automatic reconnection, message queuing, and an
+optional SSE/polling fallback for environments that block WebSocket.
 
 ## Quick Start
 
@@ -46,8 +47,15 @@ const ws = WebSocketManager.create({
   maxReconnectInterval: 30000, // Max reconnect delay ms (default: 30000)
   queueMessages: true, // Queue messages when disconnected (default: false)
   binaryType: 'arraybuffer', // Binary data type (default: 'blob')
+  fallback: 'sse', // Fallback transport: 'polling' | 'sse' | 'none' (default: 'none')
+  fallbackUrl: 'https://api.example.com/sse', // HTTP(S) receive endpoint (required if fallback set)
+  fallbackSendUrl: 'https://api.example.com/send', // HTTP(S) send endpoint (default: fallbackUrl)
+  pollInterval: 3000, // Poll interval ms for 'polling' fallback (default: 3000)
 });
 ```
+
+See [Transport Fallback](#transport-fallback) for the transport behavior and the
+server contract each fallback expects.
 
 ## WebSocketInstance
 
@@ -67,11 +75,12 @@ const ws = WebSocketManager.create({
 
 ### Properties
 
-| Property            | Type             | Description                     |
-| ------------------- | ---------------- | ------------------------------- |
-| `url`               | `string`         | WebSocket URL                   |
-| `state`             | `WebSocketState` | Current connection state        |
-| `reconnectAttempts` | `number`         | Current reconnect attempt count |
+| Property            | Type                    | Description                                                    |
+| ------------------- | ----------------------- | -------------------------------------------------------------- |
+| `url`               | `string`                | WebSocket URL                                                  |
+| `state`             | `WebSocketState`        | Current connection state                                       |
+| `reconnectAttempts` | `number`                | Current reconnect attempt count                                |
+| `activeTransport`   | `TransportKind \| null` | Live transport: `'websocket'`, `'sse'`, `'polling'`, or `null` |
 
 ### States
 
@@ -230,17 +239,72 @@ cleanups.forEach((cleanup) => cleanup());
 ws.disconnect();
 ```
 
+## Transport Fallback
+
+Some environments block WebSocket connections (strict proxies, corporate
+firewalls). Set `fallback` to keep a live channel over **Server-Sent Events** or
+**HTTP polling**, using the exact same event-based API — your app code never
+branches on transport.
+
+```typescript
+const ws = WebSocketManager.create({
+  url: 'wss://api.example.com/ws',
+  fallback: 'sse',
+  fallbackUrl: 'https://api.example.com/sse',
+  fallbackSendUrl: 'https://api.example.com/send', // optional; defaults to fallbackUrl
+});
+
+ws.onMessage((data) => console.log(data)); // same handler regardless of transport
+ws.onStateChange(() => console.log('via', ws.activeTransport)); // 'websocket' | 'sse' | 'polling'
+ws.connect();
+```
+
+### Selection behavior
+
+`connect()` tries WebSocket first. If WebSocket is unavailable, or the
+connection errors/closes before it ever opens, the manager switches to the
+configured fallback. Once WebSocket has connected at least once, later drops are
+treated as transient and reconnects stay on WebSocket. Reconnect backoff,
+message queuing, and the state machine apply to every transport.
+
+> Automatic upgrade back to WebSocket while running on a fallback is not yet
+> implemented — once fallen back, the connection stays on the fallback
+> transport.
+
+### Server contract
+
+This is a browser-only library: it provides the client transports, but **your
+server must implement the matching endpoints**. There is no proprietary protocol
+— just plain HTTP.
+
+| Fallback    | Receive (`fallbackUrl`)                                                            | Send (`fallbackSendUrl`)                       |
+| ----------- | ---------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `'sse'`     | `GET` serving a `text/event-stream`; each event's `data` becomes a message         | `POST` with the serialized message as the body |
+| `'polling'` | `GET` returning the next queued message as the body (empty body = nothing pending) | `POST` with the serialized message as the body |
+
+Inbound text is JSON-parsed exactly like WebSocket text frames; non-JSON stays a
+string.
+
+### Limitations
+
+- **Binary is WebSocket-only.** SSE and polling are text channels:
+  `sendBinary()` returns `false` and no binary messages are received while on a
+  fallback.
+- **Heartbeats are WebSocket-only.** On polling the poll itself is the liveness
+  check, and SSE streams are server-driven.
+
 ## WebSocketError
 
 ### Error Codes
 
-| Code                | Description                             |
-| ------------------- | --------------------------------------- |
-| `NOT_SUPPORTED`     | WebSocket not available                 |
-| `CONNECTION_FAILED` | Failed to establish connection          |
-| `SEND_FAILED`       | Failed to send message                  |
-| `INVALID_STATE`     | Operation not valid in current state    |
-| `INVALID_URL`       | URL does not use ws:// or wss:// scheme |
+| Code                | Description                              |
+| ------------------- | ---------------------------------------- |
+| `NOT_SUPPORTED`     | WebSocket not available                  |
+| `CONNECTION_FAILED` | Failed to establish connection           |
+| `SEND_FAILED`       | Failed to send message                   |
+| `INVALID_STATE`     | Operation not valid in current state     |
+| `INVALID_URL`       | URL does not use ws:// or wss:// scheme  |
+| `INVALID_CONFIG`    | Fallback enabled without a `fallbackUrl` |
 
 ## Security Considerations
 

--- a/src/core/errors/WebSocketError.ts
+++ b/src/core/errors/WebSocketError.ts
@@ -6,6 +6,7 @@
  * - Connection failures
  * - Send failures
  * - Invalid state or URL
+ * - Invalid fallback configuration
  *
  * @example
  * ```TypeScript
@@ -28,7 +29,8 @@ export type WebSocketErrorCode =
   | 'CONNECTION_FAILED'
   | 'SEND_FAILED'
   | 'INVALID_STATE'
-  | 'INVALID_URL';
+  | 'INVALID_URL'
+  | 'INVALID_CONFIG';
 
 /**
  * WebSocket-specific error.
@@ -60,5 +62,12 @@ export class WebSocketError extends BrowserUtilsError {
 
   static invalidUrl(url: string): WebSocketError {
     return new WebSocketError('INVALID_URL', `Invalid WebSocket URL: "${url}"`);
+  }
+
+  static fallbackUrlRequired(fallback: string): WebSocketError {
+    return new WebSocketError(
+      'INVALID_CONFIG',
+      `"fallbackUrl" is required when fallback is "${fallback}"`
+    );
   }
 }

--- a/src/websocket/PollingTransport.ts
+++ b/src/websocket/PollingTransport.ts
@@ -1,0 +1,150 @@
+/**
+ * HTTP polling fallback transport.
+ *
+ * Receives messages by polling an endpoint with `fetch` GET on an interval and sends
+ * messages with `fetch` POST. Used when WebSocket is unavailable or blocked and SSE
+ * is not desired.
+ *
+ * @remarks
+ * ## Server contract
+ *
+ * - **Receive:** each poll issues an HTTP `GET` to the `fallbackUrl`. A non-empty
+ *   response body is delivered to the manager as one message (JSON-parsed like
+ *   WebSocket text frames); an empty body means "no message this tick". The server is
+ *   expected to return the next queued message (or a batch the app decodes).
+ * - **Send:** each {@link PollingTransport.send} issues an HTTP `POST` to the send URL
+ *   with the serialized message as the request body.
+ *
+ * The transport is considered connected after the first successful poll, so "connected"
+ * reflects that the endpoint is reachable. Any failed poll closes the transport and lets
+ * the manager's reconnect backoff drive recovery. Binary frames are not supported.
+ */
+import { type Transport, noopTransportCallback } from './Transport.js';
+import type { BinaryData } from './types.js';
+
+/**
+ * Transport backed by `fetch` GET polling (receive) and `fetch` POST (send).
+ */
+export class PollingTransport implements Transport {
+  readonly kind = 'polling' as const;
+  readonly supportsBinary = false;
+
+  onOpen: () => void = noopTransportCallback;
+  onClose: (code: number, reason: string) => void = noopTransportCallback;
+  onError: (error: Event) => void = noopTransportCallback;
+  onMessage: (data: unknown, event?: MessageEvent) => void = noopTransportCallback;
+
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private hasOpened = false;
+  private closeEmitted = false;
+  /**
+   * Connection generation. Bumped on every connect/teardown so that in-flight polls
+   * started for a previous connection (still suspended on an `await`) bail out instead
+   * of firing callbacks after close or onto a newer connection.
+   */
+  private generation = 0;
+
+  constructor(
+    private readonly receiveUrl: string,
+    private readonly sendUrl: string,
+    private readonly pollInterval: number
+  ) {}
+
+  connect(): void {
+    this.closeEmitted = false;
+    this.hasOpened = false;
+    this.generation += 1;
+    void this.poll(this.generation);
+  }
+
+  send(data: string): boolean {
+    if (this.closeEmitted) return false;
+    try {
+      void fetch(this.sendUrl, { method: 'POST', body: data }).catch((e: unknown) => {
+        this.onError(e instanceof Event ? e : new Event('error'));
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendBinary(_data: BinaryData): boolean {
+    // Polling is a text-only channel; binary frames are unsupported.
+    return false;
+  }
+
+  setBinaryType(): void {
+    // No-op: binary is unsupported on polling.
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.teardown();
+    this.emitClose(code, reason);
+  }
+
+  private async poll(generation: number): Promise<void> {
+    let response: Response;
+    try {
+      response = await fetch(this.receiveUrl, { method: 'GET' });
+    } catch (e) {
+      this.fail(generation, e);
+      return;
+    }
+
+    if (generation !== this.generation) return;
+
+    if (!response.ok) {
+      this.fail(generation, new Event('error'));
+      return;
+    }
+
+    if (!this.hasOpened) {
+      this.hasOpened = true;
+      this.onOpen();
+    }
+
+    let body: string;
+    try {
+      body = await response.text();
+    } catch (e) {
+      this.fail(generation, e);
+      return;
+    }
+
+    if (generation !== this.generation) return;
+
+    if (body !== '') {
+      this.onMessage(body);
+    }
+
+    this.scheduleNext(generation);
+  }
+
+  private scheduleNext(generation: number): void {
+    this.timer = setTimeout(() => {
+      void this.poll(generation);
+    }, this.pollInterval);
+  }
+
+  private fail(generation: number, cause: unknown): void {
+    if (generation !== this.generation) return;
+    this.onError(cause instanceof Event ? cause : new Event('error'));
+    this.teardown();
+    this.emitClose(1006, 'Polling request failed');
+  }
+
+  private teardown(): void {
+    this.generation += 1;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private emitClose(code: number, reason: string): void {
+    if (this.closeEmitted) return;
+    this.closeEmitted = true;
+    this.onClose(code, reason);
+  }
+}

--- a/src/websocket/SseTransport.ts
+++ b/src/websocket/SseTransport.ts
@@ -1,0 +1,101 @@
+/**
+ * Server-Sent Events (SSE) fallback transport.
+ *
+ * Receives server-pushed messages over an `EventSource` stream and sends messages
+ * with `fetch` POST. Used when WebSocket is unavailable or blocked.
+ *
+ * @remarks
+ * ## Server contract
+ *
+ * - **Receive:** the `fallbackUrl` must serve a `text/event-stream` (SSE) response.
+ *   Each event's `data` is delivered to the manager (JSON-parsed like WebSocket text
+ *   frames).
+ * - **Send:** each {@link SseTransport.send} issues an HTTP `POST` to the send URL
+ *   with the serialized message as the request body.
+ *
+ * Binary frames are not supported (SSE is a UTF-8 text channel). On any SSE error the
+ * stream is closed and a close is emitted so the manager's reconnect backoff drives
+ * recovery uniformly, rather than racing `EventSource`'s own auto-reconnect.
+ */
+import { type Transport, noopTransportCallback } from './Transport.js';
+import type { BinaryData } from './types.js';
+
+/**
+ * Transport backed by `EventSource` (receive) and `fetch` POST (send).
+ */
+export class SseTransport implements Transport {
+  readonly kind = 'sse' as const;
+  readonly supportsBinary = false;
+
+  onOpen: () => void = noopTransportCallback;
+  onClose: (code: number, reason: string) => void = noopTransportCallback;
+  onError: (error: Event) => void = noopTransportCallback;
+  onMessage: (data: unknown, event?: MessageEvent) => void = noopTransportCallback;
+
+  private source: EventSource | null = null;
+  private closeEmitted = false;
+
+  constructor(
+    private readonly receiveUrl: string,
+    private readonly sendUrl: string
+  ) {}
+
+  connect(): void {
+    this.closeEmitted = false;
+    this.source = new EventSource(this.receiveUrl);
+
+    this.source.onopen = (): void => {
+      this.onOpen();
+    };
+
+    this.source.onmessage = (event: MessageEvent): void => {
+      this.onMessage(event.data, event);
+    };
+
+    this.source.onerror = (event: Event): void => {
+      this.onError(event);
+      // Drive reconnect through the manager instead of EventSource's auto-retry.
+      this.teardown();
+      this.emitClose(1006, 'SSE connection error');
+    };
+  }
+
+  send(data: string): boolean {
+    if (this.closeEmitted) return false;
+    try {
+      void fetch(this.sendUrl, { method: 'POST', body: data }).catch((e: unknown) => {
+        this.onError(e instanceof Event ? e : new Event('error'));
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendBinary(_data: BinaryData): boolean {
+    // SSE is a text-only channel; binary frames are unsupported.
+    return false;
+  }
+
+  setBinaryType(): void {
+    // No-op: binary is unsupported on SSE.
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.teardown();
+    this.emitClose(code, reason);
+  }
+
+  private teardown(): void {
+    if (this.source) {
+      this.source.close();
+      this.source = null;
+    }
+  }
+
+  private emitClose(code: number, reason: string): void {
+    if (this.closeEmitted) return;
+    this.closeEmitted = true;
+    this.onClose(code, reason);
+  }
+}

--- a/src/websocket/Transport.ts
+++ b/src/websocket/Transport.ts
@@ -1,0 +1,58 @@
+/**
+ * Transport abstraction for the WebSocket manager.
+ *
+ * A transport owns a single underlying connection (native WebSocket, SSE stream,
+ * or HTTP polling loop) and translates its lifecycle and inbound data into the
+ * manager's callbacks. Transport-agnostic concerns (state machine, reconnect
+ * backoff, message queue, JSON parse/serialize, handler fan-out) live in the
+ * manager layer, not here.
+ *
+ * @remarks
+ * The manager assigns the callback properties before calling {@link Transport.connect}.
+ * Outbound payloads arrive at {@link Transport.send} already serialized to a string;
+ * binary payloads go through {@link Transport.sendBinary}, which only the WebSocket
+ * transport supports (SSE and polling are text-only channels).
+ */
+import type { BinaryData, BinaryType } from './types.js';
+
+/**
+ * The kind of transport currently backing a connection.
+ */
+export type TransportKind = 'websocket' | 'sse' | 'polling';
+
+/**
+ * A single connection transport behind the manager's event API.
+ */
+export interface Transport {
+  /** Which transport this is. */
+  readonly kind: TransportKind;
+  /** Whether binary frames can be sent over this transport. */
+  readonly supportsBinary: boolean;
+
+  /** Called when the underlying connection opens. */
+  onOpen: () => void;
+  /** Called when the underlying connection closes. */
+  onClose: (code: number, reason: string) => void;
+  /** Called on a transport-level error. */
+  onError: (error: Event) => void;
+  /** Called for each inbound message (raw; the manager parses JSON / routes binary). */
+  onMessage: (data: unknown, event?: MessageEvent) => void;
+
+  /** Open the underlying connection. */
+  connect(): void;
+  /** Send an already-serialized string payload. Returns false on failure. */
+  send(data: string): boolean;
+  /** Send a binary payload. Returns false when unsupported or on failure. */
+  sendBinary(data: BinaryData): boolean;
+  /** Set the binary receive type (WebSocket only; a no-op on text transports). */
+  setBinaryType(type: BinaryType): void;
+  /** Tear down the underlying connection and clear any internal timers. */
+  close(code?: number, reason?: string): void;
+}
+
+/**
+ * No-op callback used as a default before the manager wires up its handlers.
+ */
+export const noopTransportCallback = (): void => {
+  // Intentionally empty: replaced by the manager before connect().
+};

--- a/src/websocket/WebSocketManager.ts
+++ b/src/websocket/WebSocketManager.ts
@@ -165,29 +165,21 @@
  * ```
  */
 import { WebSocketError, type WebSocketErrorCode, type CleanupFn } from '../core/index.js';
+import type { BinaryData, BinaryType, ConnectionState } from './types.js';
+import type { Transport, TransportKind } from './Transport.js';
+import { WebSocketTransport } from './WebSocketTransport.js';
+import { SseTransport } from './SseTransport.js';
+import { PollingTransport } from './PollingTransport.js';
 
 export { WebSocketError };
 export type { WebSocketErrorCode };
+export type { BinaryData, BinaryType, ConnectionState };
+export type { TransportKind };
 
 /**
- * WebSocket connection states.
+ * Transport fallback strategy when WebSocket is unavailable or fails to connect.
  */
-export type ConnectionState =
-  | 'connecting'
-  | 'connected'
-  | 'disconnecting'
-  | 'disconnected'
-  | 'reconnecting';
-
-/**
- * Binary type for WebSocket.
- */
-export type BinaryType = 'blob' | 'arraybuffer';
-
-/**
- * Binary data types that can be sent via WebSocket.
- */
-export type BinaryData = ArrayBuffer | ArrayBufferView | Blob;
+export type FallbackStrategy = 'polling' | 'sse' | 'none';
 
 /**
  * WebSocket manager configuration.
@@ -217,6 +209,24 @@ export interface WebSocketConfig {
   readonly maxQueueSize?: number;
   /** Binary type for receiving binary data ('blob' or 'arraybuffer') */
   readonly binaryType?: BinaryType;
+  /**
+   * Fallback transport when WebSocket is unavailable or fails to connect
+   * (default: 'none'). Requires {@link WebSocketConfig.fallbackUrl}.
+   */
+  readonly fallback?: FallbackStrategy;
+  /**
+   * HTTP(S) endpoint for the fallback transport (required when `fallback` is not
+   * 'none'). Receives server-pushed messages: an SSE (`text/event-stream`) stream
+   * for `'sse'`, or a polled GET resource for `'polling'`.
+   */
+  readonly fallbackUrl?: string;
+  /**
+   * HTTP(S) endpoint the fallback transport POSTs outbound messages to
+   * (default: {@link WebSocketConfig.fallbackUrl}).
+   */
+  readonly fallbackSendUrl?: string;
+  /** Polling interval in ms for the `'polling'` fallback (default: 3000). */
+  readonly pollInterval?: number;
 }
 
 /**
@@ -229,6 +239,8 @@ export interface WebSocketInstance {
   readonly url: string;
   /** Number of reconnection attempts */
   readonly reconnectAttempts: number;
+  /** The transport currently backing the connection, or null before connecting */
+  readonly activeTransport: TransportKind | null;
 
   /** Connect to the WebSocket server */
   connect(): void;
@@ -271,7 +283,21 @@ const DEFAULT_CONFIG = {
   queueMessages: true,
   maxQueueSize: 100,
   binaryType: 'blob',
+  fallback: 'none',
+  pollInterval: 3000,
 } as const satisfies Partial<WebSocketConfig>;
+
+/**
+ * Validate an HTTP(S) URL used for a fallback transport endpoint.
+ */
+const isHttpUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
 
 export const WebSocketManager = {
   /**
@@ -386,25 +412,53 @@ export const WebSocketManager = {
    *   }
    * });
    * ```
+   *
+   * @example With an SSE fallback when WebSocket is blocked
+   * ```TypeScript
+   * // Same event API regardless of transport. Requires server endpoints matching
+   * // the fallback contract (see the websocket documentation).
+   * const ws = WebSocketManager.create({
+   *   url: 'wss://api.example.com/ws',
+   *   fallback: 'sse',
+   *   fallbackUrl: 'https://api.example.com/sse',
+   *   fallbackSendUrl: 'https://api.example.com/send',
+   * });
+   *
+   * ws.onMessage((data) => console.log('Received via', ws.activeTransport, data));
+   * ws.connect();
+   * ```
    */
   create(config: WebSocketConfig): WebSocketInstance {
-    if (!WebSocketManager.isSupported()) {
-      throw WebSocketError.notSupported();
-    }
-
     if (!WebSocketManager.isValidUrl(config.url)) {
       throw WebSocketError.invalidUrl(config.url);
     }
 
     const options = { ...DEFAULT_CONFIG, ...config };
 
-    let ws: WebSocket | null = null;
+    if (options.fallback !== 'none') {
+      if (config.fallbackUrl === undefined || config.fallbackUrl.length === 0) {
+        throw WebSocketError.fallbackUrlRequired(options.fallback);
+      }
+      if (!isHttpUrl(config.fallbackUrl)) {
+        throw WebSocketError.invalidUrl(config.fallbackUrl);
+      }
+      if (config.fallbackSendUrl !== undefined && !isHttpUrl(config.fallbackSendUrl)) {
+        throw WebSocketError.invalidUrl(config.fallbackSendUrl);
+      }
+    } else if (!WebSocketManager.isSupported()) {
+      // No fallback configured and WebSocket is unavailable.
+      throw WebSocketError.notSupported();
+    }
+
+    let activeTransport: Transport | null = null;
     let state: ConnectionState = 'disconnected';
     let reconnectAttempts = 0;
     let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
-    let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
     const messageQueue: unknown[] = [];
     let intentionalClose = false;
+    let hasFallenBack = false;
+    let wsEverConnected = false;
     let currentBinaryType: BinaryType = options.binaryType;
 
     // Event handlers
@@ -423,49 +477,90 @@ export const WebSocketManager = {
       }
     };
 
-    const clearTimers = (): void => {
+    const stopHeartbeat = (): void => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+    };
+
+    const clearReconnectTimer = (): void => {
       if (reconnectTimeout) {
         clearTimeout(reconnectTimeout);
         reconnectTimeout = null;
       }
-      if (heartbeatInterval) {
-        clearInterval(heartbeatInterval);
-        heartbeatInterval = null;
-      }
     };
 
+    const clearTimers = (): void => {
+      clearReconnectTimer();
+      stopHeartbeat();
+    };
+
+    /**
+     * Check if data is binary (ArrayBuffer or Blob).
+     */
+    const isBinaryData = (data: unknown): data is ArrayBuffer | Blob => {
+      return data instanceof ArrayBuffer || data instanceof Blob;
+    };
+
+    // Heartbeat is a WebSocket-only concern: on polling the poll itself is the
+    // liveness check, and SSE streams are server-driven. Sending heartbeats over a
+    // fallback would just generate surprise POST traffic.
     const startHeartbeat = (): void => {
       if (options.heartbeatInterval <= 0) return;
+      if (activeTransport?.kind !== 'websocket') return;
 
-      heartbeatInterval = setInterval(() => {
-        if (ws?.readyState === WebSocket.OPEN) {
-          try {
-            const message =
-              typeof options.heartbeatMessage === 'function'
-                ? options.heartbeatMessage()
-                : (options.heartbeatMessage ?? 'ping');
+      heartbeatTimer = setInterval(() => {
+        if (state !== 'connected' || !activeTransport) return;
 
-            ws.send(typeof message === 'string' ? message : JSON.stringify(message));
-          } catch (e) {
-            errorHandlers.forEach((handler) =>
-              handler(e instanceof Event ? e : new Event('error'))
-            );
-          }
+        try {
+          const message =
+            typeof options.heartbeatMessage === 'function'
+              ? options.heartbeatMessage()
+              : (options.heartbeatMessage ?? 'ping');
+
+          activeTransport.send(typeof message === 'string' ? message : JSON.stringify(message));
+        } catch (e) {
+          errorHandlers.forEach((handler) => handler(e instanceof Event ? e : new Event('error')));
         }
       }, options.heartbeatInterval);
     };
 
     const flushQueue = (): void => {
-      while (messageQueue.length > 0 && ws?.readyState === WebSocket.OPEN) {
+      while (messageQueue.length > 0 && state === 'connected' && activeTransport) {
         const data = messageQueue.shift();
-        try {
-          ws.send(typeof data === 'string' ? data : JSON.stringify(data));
-        } catch {
+        const serialized = typeof data === 'string' ? data : JSON.stringify(data);
+        if (!activeTransport.send(serialized)) {
           // Put message back in queue
           messageQueue.unshift(data);
           break;
         }
       }
+    };
+
+    const handleMessage = (data: unknown, event?: MessageEvent): void => {
+      // Handle binary data (WebSocket only).
+      if (isBinaryData(data)) {
+        binaryMessageHandlers.forEach((handler) => handler(data));
+        const messageEvent = event ?? new MessageEvent('message', { data });
+        messageHandlers.forEach((handler) => handler(data, messageEvent));
+        return;
+      }
+
+      // Try to parse JSON for string messages.
+      let parsedData: unknown = data;
+      if (typeof data === 'string') {
+        try {
+          parsedData = JSON.parse(data);
+        } catch {
+          // Keep as string
+        }
+      }
+
+      // Fallback transports without a native MessageEvent get a synthetic one so the
+      // event-based API stays uniform across transports.
+      const messageEvent = event ?? new MessageEvent('message', { data });
+      messageHandlers.forEach((handler) => handler(parsedData, messageEvent));
     };
 
     const scheduleReconnect = (): void => {
@@ -489,74 +584,98 @@ export const WebSocketManager = {
       }, delay);
     };
 
-    /**
-     * Check if data is binary (ArrayBuffer or Blob).
-     */
-    const isBinaryData = (data: unknown): data is ArrayBuffer | Blob => {
-      return data instanceof ArrayBuffer || data instanceof Blob;
+    // Fall back only while WebSocket has never connected: once it has worked, drops are
+    // treated as transient and reconnect stays on WebSocket.
+    const canFallback = (): boolean =>
+      options.fallback !== 'none' &&
+      !hasFallenBack &&
+      !wsEverConnected &&
+      activeTransport?.kind === 'websocket';
+
+    const createFallbackTransport = (): Transport => {
+      const receiveUrl = config.fallbackUrl as string;
+      const sendUrl = config.fallbackSendUrl ?? receiveUrl;
+      return options.fallback === 'sse'
+        ? new SseTransport(receiveUrl, sendUrl)
+        : new PollingTransport(receiveUrl, sendUrl, options.pollInterval);
+    };
+
+    const createInitialTransport = (): Transport => {
+      if (WebSocketManager.isSupported()) {
+        return new WebSocketTransport(config.url, config.protocols, currentBinaryType);
+      }
+      // WebSocket is unavailable but a fallback is configured (validated above).
+      hasFallenBack = true;
+      return createFallbackTransport();
+    };
+
+    const wireTransport = (transport: Transport): void => {
+      transport.onOpen = (): void => {
+        if (transport.kind === 'websocket') wsEverConnected = true;
+        setState('connected');
+        reconnectAttempts = 0;
+        startHeartbeat();
+        flushQueue();
+        openHandlers.forEach((handler) => handler());
+      };
+
+      transport.onClose = (code: number, reason: string): void => {
+        stopHeartbeat();
+        closeHandlers.forEach((handler) => handler(code, reason));
+
+        if (intentionalClose) {
+          setState('disconnected');
+          return;
+        }
+
+        if (canFallback()) {
+          switchToFallback();
+          return;
+        }
+
+        scheduleReconnect();
+      };
+
+      transport.onError = (event: Event): void => {
+        errorHandlers.forEach((handler) => handler(event));
+      };
+
+      transport.onMessage = handleMessage;
+    };
+
+    const switchToFallback = (): void => {
+      hasFallenBack = true;
+      stopHeartbeat();
+      activeTransport = createFallbackTransport();
+      wireTransport(activeTransport);
+      reconnectAttempts = 0;
+      setState('connecting');
+      activeTransport.connect();
     };
 
     const connect = (): void => {
-      if (ws?.readyState === WebSocket.OPEN || ws?.readyState === WebSocket.CONNECTING) {
+      if (state === 'connecting' || state === 'connected') {
         return;
       }
 
       intentionalClose = false;
+
+      if (!activeTransport) {
+        activeTransport = createInitialTransport();
+        wireTransport(activeTransport);
+      }
+
       setState('connecting');
 
       try {
-        ws = new WebSocket(config.url, config.protocols);
-        ws.binaryType = currentBinaryType;
-
-        ws.onopen = (): void => {
-          setState('connected');
-          reconnectAttempts = 0;
-          startHeartbeat();
-          flushQueue();
-          openHandlers.forEach((handler) => handler());
-        };
-
-        ws.onclose = (event): void => {
-          clearTimers();
-          closeHandlers.forEach((handler) => handler(event.code, event.reason));
-
-          if (!intentionalClose) {
-            scheduleReconnect();
-          } else {
-            setState('disconnected');
-          }
-        };
-
-        ws.onerror = (event): void => {
-          errorHandlers.forEach((handler) => handler(event));
-        };
-
-        ws.onmessage = (event): void => {
-          const data: unknown = event.data;
-
-          // Handle binary data
-          if (isBinaryData(data)) {
-            binaryMessageHandlers.forEach((handler) => handler(data));
-            // Also pass to regular message handlers
-            messageHandlers.forEach((handler) => handler(data, event));
-            return;
-          }
-
-          // Try to parse JSON for string messages
-          let parsedData: unknown = data;
-          if (typeof data === 'string') {
-            try {
-              parsedData = JSON.parse(data);
-            } catch {
-              // Keep as string
-            }
-          }
-
-          messageHandlers.forEach((handler) => handler(parsedData, event));
-        };
+        activeTransport.connect();
       } catch (e) {
+        if (canFallback()) {
+          switchToFallback();
+          return;
+        }
         setState('disconnected');
-        throw WebSocketError.connectionFailed(config.url, e);
+        throw e;
       }
     };
 
@@ -573,16 +692,16 @@ export const WebSocketManager = {
         return reconnectAttempts;
       },
 
+      get activeTransport(): TransportKind | null {
+        return activeTransport ? activeTransport.kind : null;
+      },
+
       connect,
 
       send(data: unknown): boolean {
-        if (ws?.readyState === WebSocket.OPEN) {
-          try {
-            ws.send(typeof data === 'string' ? data : JSON.stringify(data));
-            return true;
-          } catch {
-            return false;
-          }
+        if (state === 'connected' && activeTransport) {
+          const serialized = typeof data === 'string' ? data : JSON.stringify(data);
+          return activeTransport.send(serialized);
         }
 
         // Queue message if enabled
@@ -595,22 +714,12 @@ export const WebSocketManager = {
       },
 
       sendBinary(data: BinaryData): boolean {
-        if (ws?.readyState === WebSocket.OPEN) {
-          try {
-            ws.send(data as string | ArrayBuffer | Blob);
-            return true;
-          } catch {
-            return false;
-          }
-        }
-        return false;
+        return activeTransport?.sendBinary(data) ?? false;
       },
 
       setBinaryType(type: BinaryType): void {
         currentBinaryType = type;
-        if (ws) {
-          ws.binaryType = type;
-        }
+        activeTransport?.setBinaryType(type);
       },
 
       getBinaryType(): BinaryType {
@@ -622,9 +731,9 @@ export const WebSocketManager = {
         clearTimers();
         messageQueue.length = 0;
 
-        if (ws && ws.readyState !== WebSocket.CLOSED) {
+        if (activeTransport && state !== 'disconnected') {
           setState('disconnecting');
-          ws.close(code, reason);
+          activeTransport.close(code, reason);
         } else {
           setState('disconnected');
         }

--- a/src/websocket/WebSocketTransport.ts
+++ b/src/websocket/WebSocketTransport.ts
@@ -1,0 +1,98 @@
+/**
+ * Native WebSocket transport.
+ *
+ * Wraps a single `WebSocket` connection and forwards its lifecycle and inbound
+ * data to the manager. This is the preferred transport; SSE and polling are only
+ * used as fallbacks when WebSocket is unavailable or fails to connect.
+ */
+import { WebSocketError } from '../core/index.js';
+import { type Transport, noopTransportCallback } from './Transport.js';
+import type { BinaryData, BinaryType } from './types.js';
+
+/**
+ * Transport backed by the native `WebSocket` API.
+ */
+export class WebSocketTransport implements Transport {
+  readonly kind = 'websocket' as const;
+  readonly supportsBinary = true;
+
+  onOpen: () => void = noopTransportCallback;
+  onClose: (code: number, reason: string) => void = noopTransportCallback;
+  onError: (error: Event) => void = noopTransportCallback;
+  onMessage: (data: unknown, event?: MessageEvent) => void = noopTransportCallback;
+
+  private ws: WebSocket | null = null;
+  private binaryType: BinaryType;
+
+  constructor(
+    private readonly url: string,
+    private readonly protocols: string | string[] | undefined,
+    binaryType: BinaryType
+  ) {
+    this.binaryType = binaryType;
+  }
+
+  connect(): void {
+    // The manager owns connection-state guarding and only calls connect() when the
+    // previous socket (if any) has closed, so no idempotency check is needed here.
+    try {
+      this.ws = new WebSocket(this.url, this.protocols);
+      this.ws.binaryType = this.binaryType;
+
+      this.ws.onopen = (): void => {
+        this.onOpen();
+      };
+
+      this.ws.onclose = (event): void => {
+        this.onClose(event.code, event.reason);
+      };
+
+      this.ws.onerror = (event): void => {
+        this.onError(event);
+      };
+
+      this.ws.onmessage = (event): void => {
+        this.onMessage(event.data, event);
+      };
+    } catch (e) {
+      throw WebSocketError.connectionFailed(this.url, e);
+    }
+  }
+
+  send(data: string): boolean {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(data);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  sendBinary(data: BinaryData): boolean {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(data as string | ArrayBuffer | Blob);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  setBinaryType(type: BinaryType): void {
+    this.binaryType = type;
+    if (this.ws) {
+      this.ws.binaryType = type;
+    }
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (this.ws && this.ws.readyState !== WebSocket.CLOSED) {
+      this.ws.close(code, reason);
+    }
+  }
+}

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -7,4 +7,6 @@ export {
   type WebSocketInstance,
   type BinaryType,
   type BinaryData,
+  type FallbackStrategy,
+  type TransportKind,
 } from './WebSocketManager.js';

--- a/src/websocket/types.ts
+++ b/src/websocket/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared type definitions for the WebSocket module.
+ *
+ * Extracted so transports and the manager can share them without importing each
+ * other (avoids a circular dependency between the manager and its transports).
+ */
+
+/**
+ * Binary type for WebSocket.
+ */
+export type BinaryType = 'blob' | 'arraybuffer';
+
+/**
+ * Binary data types that can be sent via WebSocket.
+ */
+export type BinaryData = ArrayBuffer | ArrayBufferView | Blob;
+
+/**
+ * WebSocket connection states.
+ */
+export type ConnectionState =
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'disconnected'
+  | 'reconnecting';

--- a/tests/websocket/WebSocketManager.test.ts
+++ b/tests/websocket/WebSocketManager.test.ts
@@ -906,6 +906,19 @@ describe('WebSocketManager', () => {
         expect(result).toBe(false);
       });
 
+      it('should return false when sendBinary called before the socket opens', () => {
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          reconnect: false,
+        });
+
+        ws.connect();
+        // Socket is created but still CONNECTING (readyState 0).
+        const result = ws.sendBinary(new ArrayBuffer(8));
+
+        expect(result).toBe(false);
+      });
+
       it('should return false when sendBinary throws', () => {
         const ws = WebSocketManager.create({
           url: 'wss://example.com',
@@ -1240,6 +1253,576 @@ describe('WebSocketManager', () => {
       expect(() => ws.connect()).toThrow(WebSocketError);
       expect(() => ws.connect()).toThrow('Failed to connect');
       expect(stateHandler).toHaveBeenCalledWith('disconnected');
+    });
+  });
+
+  describe('Transport Fallback', () => {
+    interface MockWs {
+      readyState: number;
+      binaryType: string;
+      close: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+      onopen: (() => void) | null;
+      onclose: ((e: { code: number; reason: string }) => void) | null;
+      onerror: ((e: Event) => void) | null;
+      onmessage: ((e: { data: unknown }) => void) | null;
+    }
+
+    let wsInstances: MockWs[];
+    let esInstances: MockEventSource[];
+    let fetchMock: ReturnType<typeof vi.fn>;
+    let originalWs: typeof WebSocket;
+    let originalEventSource: typeof EventSource;
+    let originalFetch: typeof fetch;
+
+    class MockEventSource {
+      onopen: ((e: Event) => void) | null = null;
+      onmessage: ((e: MessageEvent) => void) | null = null;
+      onerror: ((e: Event) => void) | null = null;
+      close = vi.fn();
+
+      constructor(public url: string) {
+        esInstances.push(this);
+      }
+    }
+
+    const makeWs = (): MockWs => ({
+      readyState: 0,
+      binaryType: 'blob',
+      close: vi.fn(),
+      send: vi.fn(),
+      onopen: null,
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+    });
+
+    const httpResponse = (body: string, ok = true): Response =>
+      ({ ok, text: (): Promise<string> => Promise.resolve(body) }) as unknown as Response;
+
+    const flush = async (): Promise<void> => {
+      for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+      }
+    };
+
+    const removeWebSocket = (): void => {
+      // @ts-expect-error - Testing WebSocket-unavailable environments
+      delete globalThis.WebSocket;
+    };
+
+    const lastWs = (): MockWs => {
+      const instance = wsInstances.at(-1);
+      if (instance === undefined) throw new Error('no WebSocket created');
+      return instance;
+    };
+
+    const lastEs = (): MockEventSource => {
+      const instance = esInstances.at(-1);
+      if (instance === undefined) throw new Error('no EventSource created');
+      return instance;
+    };
+
+    beforeEach(() => {
+      wsInstances = [];
+      esInstances = [];
+
+      const MockWebSocket = vi.fn().mockImplementation(function (this: void) {
+        const instance = makeWs();
+        wsInstances.push(instance);
+        return instance;
+      });
+      // @ts-expect-error - Mock WebSocket constants
+      MockWebSocket.CONNECTING = 0;
+      // @ts-expect-error - Mock WebSocket constants
+      MockWebSocket.OPEN = 1;
+      // @ts-expect-error - Mock WebSocket constants
+      MockWebSocket.CLOSING = 2;
+      // @ts-expect-error - Mock WebSocket constants
+      MockWebSocket.CLOSED = 3;
+      originalWs = globalThis.WebSocket;
+      globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+
+      originalEventSource = globalThis.EventSource;
+      globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+      originalFetch = globalThis.fetch;
+      fetchMock = vi.fn().mockResolvedValue(httpResponse(''));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.WebSocket = originalWs;
+      globalThis.EventSource = originalEventSource;
+      globalThis.fetch = originalFetch;
+      vi.useRealTimers();
+    });
+
+    const codeOf = (fn: () => unknown): string | undefined => {
+      try {
+        fn();
+      } catch (e) {
+        return (e as WebSocketError).code;
+      }
+      return undefined;
+    };
+
+    describe('configuration validation', () => {
+      it('should throw INVALID_CONFIG when fallback is set without fallbackUrl', () => {
+        expect(
+          codeOf(() => WebSocketManager.create({ url: 'wss://example.com', fallback: 'sse' }))
+        ).toBe('INVALID_CONFIG');
+        expect(
+          codeOf(() => WebSocketManager.create({ url: 'wss://example.com', fallback: 'polling' }))
+        ).toBe('INVALID_CONFIG');
+      });
+
+      it('should throw INVALID_URL when fallbackUrl is not http(s)', () => {
+        expect(
+          codeOf(() =>
+            WebSocketManager.create({
+              url: 'wss://example.com',
+              fallback: 'sse',
+              fallbackUrl: 'ws://example.com/sse',
+            })
+          )
+        ).toBe('INVALID_URL');
+      });
+
+      it('should throw INVALID_URL when fallbackSendUrl is not http(s)', () => {
+        expect(
+          codeOf(() =>
+            WebSocketManager.create({
+              url: 'wss://example.com',
+              fallback: 'sse',
+              fallbackUrl: 'https://example.com/sse',
+              fallbackSendUrl: 'ftp://example.com/send',
+            })
+          )
+        ).toBe('INVALID_URL');
+      });
+
+      it('should accept a valid fallback configuration', () => {
+        expect(() =>
+          WebSocketManager.create({
+            url: 'wss://example.com',
+            fallback: 'sse',
+            fallbackUrl: 'https://example.com/sse',
+          })
+        ).not.toThrow();
+      });
+    });
+
+    describe('transport selection', () => {
+      it('should use the SSE fallback when WebSocket is unsupported', () => {
+        removeWebSocket();
+
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'sse',
+          fallbackUrl: 'https://example.com/sse',
+        });
+        const openHandler = vi.fn();
+        ws.onOpen(openHandler);
+
+        ws.connect();
+        expect(ws.activeTransport).toBe('sse');
+
+        lastEs().onopen?.(new Event('open'));
+        expect(openHandler).toHaveBeenCalled();
+        expect(ws.state).toBe('connected');
+      });
+
+      it('should use the polling fallback when WebSocket is unsupported', () => {
+        removeWebSocket();
+
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'polling',
+          fallbackUrl: 'https://example.com/poll',
+        });
+
+        ws.connect();
+        expect(ws.activeTransport).toBe('polling');
+      });
+
+      it('should fall back when the WebSocket closes before opening', () => {
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'polling',
+          fallbackUrl: 'https://example.com/poll',
+        });
+
+        ws.connect();
+        expect(ws.activeTransport).toBe('websocket');
+
+        // Connection errors and closes before ever opening (e.g. blocked by proxy).
+        lastWs().onclose?.({ code: 1006, reason: 'blocked' });
+        expect(ws.activeTransport).toBe('polling');
+      });
+
+      it('should fall back when the WebSocket constructor throws', () => {
+        const ThrowingWebSocket = vi.fn().mockImplementation(function (this: void) {
+          throw new Error('blocked');
+        });
+        // @ts-expect-error - Mock WebSocket constants
+        ThrowingWebSocket.CONNECTING = 0;
+        // @ts-expect-error - Mock WebSocket constants
+        ThrowingWebSocket.OPEN = 1;
+        // @ts-expect-error - Mock WebSocket constants
+        ThrowingWebSocket.CLOSING = 2;
+        // @ts-expect-error - Mock WebSocket constants
+        ThrowingWebSocket.CLOSED = 3;
+        globalThis.WebSocket = ThrowingWebSocket as unknown as typeof WebSocket;
+
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'polling',
+          fallbackUrl: 'https://example.com/poll',
+        });
+
+        ws.connect();
+        expect(ws.activeTransport).toBe('polling');
+      });
+
+      it('should stay on WebSocket once it connects, even with a fallback configured', () => {
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'sse',
+          fallbackUrl: 'https://example.com/sse',
+        });
+
+        ws.connect();
+        lastWs().readyState = 1;
+        lastWs().onopen?.();
+        expect(ws.activeTransport).toBe('websocket');
+        expect(ws.state).toBe('connected');
+
+        // A later drop is treated as transient: reconnect stays on WebSocket.
+        lastWs().readyState = 3;
+        lastWs().onclose?.({ code: 1006, reason: 'lost' });
+        expect(ws.activeTransport).toBe('websocket');
+      });
+    });
+
+    describe('SSE transport', () => {
+      const createSse = (
+        config: Partial<Parameters<typeof WebSocketManager.create>[0]> = {}
+      ): ReturnType<typeof WebSocketManager.create> => {
+        removeWebSocket();
+        return WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'sse',
+          fallbackUrl: 'https://example.com/sse',
+          ...config,
+        });
+      };
+
+      it('should deliver SSE messages parsed as JSON with a MessageEvent', () => {
+        const ws = createSse({ heartbeatInterval: 1000 });
+        const messageHandler = vi.fn();
+        ws.onMessage(messageHandler);
+
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+        lastEs().onmessage?.(new MessageEvent('message', { data: '{"a":1}' }));
+
+        expect(messageHandler).toHaveBeenCalledWith({ a: 1 }, expect.any(MessageEvent));
+      });
+
+      it('should POST messages to the fallback URL by default', () => {
+        const ws = createSse();
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        ws.send({ hello: 'world' });
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://example.com/sse',
+          expect.objectContaining({ method: 'POST', body: JSON.stringify({ hello: 'world' }) })
+        );
+      });
+
+      it('should POST messages to a separate fallbackSendUrl when provided', () => {
+        const ws = createSse({ fallbackSendUrl: 'https://example.com/send' });
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        ws.send('hi');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://example.com/send',
+          expect.objectContaining({ method: 'POST', body: 'hi' })
+        );
+      });
+
+      it('should not support binary sends', () => {
+        const ws = createSse();
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        expect(ws.sendBinary(new ArrayBuffer(8))).toBe(false);
+      });
+
+      it('should treat setBinaryType as a no-op on SSE', () => {
+        const ws = createSse();
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        expect(() => ws.setBinaryType('arraybuffer')).not.toThrow();
+        expect(ws.getBinaryType()).toBe('arraybuffer');
+      });
+
+      it('should reconnect after an SSE error', () => {
+        const ws = createSse({ reconnect: true, reconnectDelay: 1000 });
+        const stateHandler = vi.fn();
+        ws.onStateChange(stateHandler);
+
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+        lastEs().onerror?.(new Event('error'));
+
+        expect(lastEs().close).toHaveBeenCalled();
+        expect(stateHandler).toHaveBeenCalledWith('reconnecting');
+      });
+
+      it('should report errors when a send POST rejects', async () => {
+        const ws = createSse();
+        const errorHandler = vi.fn();
+        ws.onError(errorHandler);
+
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        fetchMock.mockRejectedValueOnce(new Error('post failed'));
+        ws.send('boom');
+        await flush();
+
+        expect(errorHandler).toHaveBeenCalled();
+      });
+
+      it('should return false when a send throws synchronously', () => {
+        const ws = createSse();
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        fetchMock.mockImplementationOnce(() => {
+          throw new Error('sync failure');
+        });
+        expect(ws.send('x')).toBe(false);
+      });
+
+      it('should close cleanly when the connection is closed', () => {
+        const ws = createSse();
+        const closeHandler = vi.fn();
+        ws.onClose(closeHandler);
+
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+        ws.close();
+
+        expect(lastEs().close).toHaveBeenCalled();
+        expect(ws.state).toBe('disconnected');
+        expect(closeHandler).toHaveBeenCalled();
+      });
+    });
+
+    describe('polling transport', () => {
+      const createPolling = (
+        config: Partial<Parameters<typeof WebSocketManager.create>[0]> = {}
+      ): ReturnType<typeof WebSocketManager.create> => {
+        removeWebSocket();
+        return WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'polling',
+          fallbackUrl: 'https://example.com/poll',
+          pollInterval: 1000,
+          ...config,
+        });
+      };
+
+      it('should poll for messages and respect the poll interval', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse('{"n":1}'));
+
+        const ws = createPolling();
+        const messageHandler = vi.fn();
+        const openHandler = vi.fn();
+        ws.onMessage(messageHandler);
+        ws.onOpen(openHandler);
+
+        ws.connect();
+        await flush();
+
+        expect(openHandler).toHaveBeenCalled();
+        expect(ws.state).toBe('connected');
+        expect(messageHandler).toHaveBeenCalledWith({ n: 1 }, expect.any(MessageEvent));
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      it('should keep polling when the response body is empty', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse(''));
+
+        const ws = createPolling();
+        const messageHandler = vi.fn();
+        ws.onMessage(messageHandler);
+
+        ws.connect();
+        await flush();
+
+        expect(ws.state).toBe('connected');
+        expect(messageHandler).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      it('should POST messages when sending', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse(''));
+
+        const ws = createPolling();
+        ws.connect();
+        await flush();
+
+        ws.send('ping');
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://example.com/poll',
+          expect.objectContaining({ method: 'POST', body: 'ping' })
+        );
+      });
+
+      it('should reconnect when a poll request rejects', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockRejectedValue(new Error('network'));
+
+        const ws = createPolling({ reconnect: true, reconnectDelay: 500 });
+        const stateHandler = vi.fn();
+        ws.onStateChange(stateHandler);
+
+        ws.connect();
+        await flush();
+
+        expect(stateHandler).toHaveBeenCalledWith('reconnecting');
+      });
+
+      it('should reconnect when a poll response is not ok', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse('', false));
+
+        const ws = createPolling({ reconnect: true, reconnectDelay: 500 });
+        const stateHandler = vi.fn();
+        ws.onStateChange(stateHandler);
+
+        ws.connect();
+        await flush();
+
+        expect(stateHandler).toHaveBeenCalledWith('reconnecting');
+      });
+
+      it('should stop polling after close', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse(''));
+
+        const ws = createPolling({ reconnect: false });
+        ws.connect();
+        await flush();
+
+        const callsAfterConnect = fetchMock.mock.calls.length;
+        ws.close();
+        await vi.advanceTimersByTimeAsync(3000);
+
+        expect(fetchMock.mock.calls.length).toBe(callsAfterConnect);
+        expect(ws.state).toBe('disconnected');
+      });
+
+      it('should not support binary sends', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue(httpResponse(''));
+
+        const ws = createPolling();
+        ws.connect();
+        await flush();
+
+        expect(ws.sendBinary(new ArrayBuffer(8))).toBe(false);
+      });
+
+      it('should report errors when a send POST rejects', async () => {
+        vi.useFakeTimers();
+        // GET polls resolve; the POST send rejects.
+        fetchMock.mockImplementation((_url: string, options?: RequestInit) =>
+          options?.method === 'POST'
+            ? Promise.reject(new Error('post failed'))
+            : Promise.resolve(httpResponse(''))
+        );
+
+        const ws = createPolling();
+        const errorHandler = vi.fn();
+        ws.onError(errorHandler);
+        ws.connect();
+        await flush();
+
+        ws.send('boom');
+        await flush();
+
+        expect(errorHandler).toHaveBeenCalled();
+      });
+
+      it('should return false when a send throws synchronously', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockImplementation((_url: string, options?: RequestInit) => {
+          if (options?.method === 'POST') throw new Error('sync failure');
+          return Promise.resolve(httpResponse(''));
+        });
+
+        const ws = createPolling();
+        ws.connect();
+        await flush();
+
+        expect(ws.send('x')).toBe(false);
+      });
+
+      it('should reconnect when reading the response body fails', async () => {
+        vi.useFakeTimers();
+        fetchMock.mockResolvedValue({
+          ok: true,
+          text: (): Promise<string> => Promise.reject(new Error('read failed')),
+        } as unknown as Response);
+
+        const ws = createPolling({ reconnect: true, reconnectDelay: 500 });
+        const stateHandler = vi.fn();
+        ws.onStateChange(stateHandler);
+        ws.connect();
+        await flush();
+
+        expect(stateHandler).toHaveBeenCalledWith('reconnecting');
+      });
+    });
+
+    describe('message queue with fallback', () => {
+      it('should flush queued messages once the fallback connects', () => {
+        removeWebSocket();
+        fetchMock.mockResolvedValue(httpResponse(''));
+
+        const ws = WebSocketManager.create({
+          url: 'wss://example.com',
+          fallback: 'sse',
+          fallbackUrl: 'https://example.com/sse',
+          queueMessages: true,
+        });
+
+        // Queued while disconnected.
+        ws.send({ q: 1 });
+        ws.connect();
+        lastEs().onopen?.(new Event('open'));
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          'https://example.com/sse',
+          expect.objectContaining({ method: 'POST', body: JSON.stringify({ q: 1 }) })
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds an **optional transport fallback** to `WebSocketManager` for environments that block WebSocket (strict proxies, corporate firewalls). When WebSocket is unavailable or fails before its first open, the manager switches to a configured fallback — **Server-Sent Events** or **HTTP polling** — behind the *same* event-based API, so consumer code never branches on transport.

Closes #96.

## What changed

- Internal `Transport` interface with three implementations: `WebSocketTransport`, `SseTransport` (EventSource receive + `fetch` POST send), `PollingTransport` (`fetch` GET loop + POST send). The manager keeps the transport-agnostic concerns (state machine, reconnect backoff, message queue + flush, JSON parse/serialize, handler fan-out, selection).
- New config: `fallback` (`'polling' | 'sse' | 'none'`, default `'none'`), `fallbackUrl` (required when fallback is set), `fallbackSendUrl`, `pollInterval`.
- New `activeTransport` getter and `INVALID_CONFIG` error code.
- Binary and heartbeat stay WebSocket-only; SSE/polling are text channels.
- Documented the server contract each fallback expects (`documentation/websocket.md`).

## Selection behavior

Try WebSocket first. If WebSocket is unsupported, or errors/closes before its first open, switch to the fallback. Once WebSocket has connected at least once, later drops reconnect on WebSocket. After falling back, reconnects stay on the fallback transport.

## Test plan

- `pnpm run typecheck` · `pnpm run lint` (0 warnings) · `pnpm run format:check`
- `pnpm run test:coverage` — 4518 tests pass; coverage above thresholds (lines 99.94 / branches 96.91 / funcs 99.51)
- `pnpm run build` · `pnpm run lint:md` · `pnpm run lint:package` · `pnpm run size:check` (websocket 2.34 kB / 2.5 kB)
- Security review: no findings.

## Follow-ups

- #146 — automatic upgrade back to WebSocket while on a fallback (deferred)
- #147 — docs(websocket): fix pre-existing config/method drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)