### PR TITLE
test: kill surviving mutants in encryption, request, and cookie modules (#98)

### DIFF
--- a/tests/cookie/CookieOptions.test.ts
+++ b/tests/cookie/CookieOptions.test.ts
@@ -646,4 +646,63 @@ describe('CookieOptions', () => {
       expect(options.expires).toBeUndefined();
     });
   });
+
+  // ===========================================================================
+  // Mutation Hardening
+  // ===========================================================================
+
+  describe('Mutation Hardening', () => {
+    /** Run a factory expected to fail and return its ValidationError. */
+    function captureValidationError(fn: () => unknown): ValidationError {
+      try {
+        fn();
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          return error;
+        }
+        throw error;
+      }
+      throw new Error('expected a ValidationError to be thrown');
+    }
+
+    it('should serialize attributes without any stray leading part', () => {
+      const options = CookieOptions.create({
+        name: 'c',
+        path: '/',
+        secure: false,
+        sameSite: 'Strict',
+      });
+
+      // Pins the exact output so a seeded extra array element is caught.
+      expect(options.toAttributeString()).toBe('path=/; samesite=Strict');
+    });
+
+    it('should tag a non-slash path error with field "cookiePath"', () => {
+      const error = captureValidationError(() =>
+        CookieOptions.create({ name: 'c', path: 'no-slash' })
+      );
+
+      expect(error.field).toBe('cookiePath');
+    });
+
+    it('should tag a forbidden-char path error with field "cookiePath"', () => {
+      const error = captureValidationError(() => CookieOptions.create({ name: 'c', path: '/a;b' }));
+
+      expect(error.field).toBe('cookiePath');
+    });
+
+    it('should tag an empty-domain error with field "cookieDomain"', () => {
+      const error = captureValidationError(() => CookieOptions.create({ name: 'c', domain: '' }));
+
+      expect(error.field).toBe('cookieDomain');
+    });
+
+    it('should tag a forbidden-char domain error with field "cookieDomain"', () => {
+      const error = captureValidationError(() =>
+        CookieOptions.create({ name: 'c', domain: 'a;b' })
+      );
+
+      expect(error.field).toBe('cookieDomain');
+    });
+  });
 });

--- a/tests/encryption/EncryptedStorage.test.ts
+++ b/tests/encryption/EncryptedStorage.test.ts
@@ -1319,4 +1319,278 @@ describe('EncryptedStorage', () => {
       expect(EncryptionError.storageUnavailable('test reason').message).toContain('test reason');
     });
   });
+
+  // ===========================================================================
+  // Mutation Hardening
+  //
+  // Targeted tests that assert *observable distinctions* (error codes, fields,
+  // success vs. failure) rather than just error types, so that logic mutations
+  // in validation, entry-format checks, quota detection, and prefix filtering
+  // are detected.
+  // ===========================================================================
+
+  describe('Mutation Hardening', () => {
+    describe('password length validation', () => {
+      it('should reject a short password even when it has enough character classes', async () => {
+        // 'Ab1' is only 3 chars (< 12) but already has 3 character classes, so
+        // the rejection must come from the length check, not the complexity check.
+        await expect(
+          EncryptedStorage.create({
+            password: 'Ab1',
+            minCharacterClasses: 1,
+            storage: mockStorage,
+          })
+        ).rejects.toMatchObject({ field: 'password' });
+      });
+    });
+
+    describe('minCharacterClasses range validation', () => {
+      it('should report minCharacterClasses (not password) as the invalid field when above 4', async () => {
+        // minCharacterClasses = 5 must be flagged by the range check itself
+        // (field 'minCharacterClasses'), not fall through to the complexity
+        // check (field 'password').
+        await expect(
+          EncryptedStorage.create({
+            password: 'Password123!',
+            minCharacterClasses: 5,
+            storage: mockStorage,
+          })
+        ).rejects.toMatchObject({ field: 'minCharacterClasses' });
+      });
+    });
+
+    describe('character class counting', () => {
+      it('should count lowercase as its own class (reject when only upper+digit present)', async () => {
+        // 'PASSWORD1234' has uppercase + digits = 2 classes and NO lowercase.
+        // Requiring 3 classes must fail; if lowercase were always counted the
+        // count would wrongly reach 3 and creation would succeed.
+        await expect(
+          EncryptedStorage.create({
+            password: 'PASSWORD1234',
+            minCharacterClasses: 3,
+            storage: mockStorage,
+          })
+        ).rejects.toThrow(ValidationError);
+      });
+    });
+
+    describe('iterations boundary', () => {
+      it('should accept iterations exactly equal to the minimum', async () => {
+        // Boundary: iterations === MIN_ITERATIONS (10_000) must be allowed,
+        // distinguishing `< MIN` from `<= MIN`.
+        const storage = await EncryptedStorage.create({
+          password: 'secure-password-123',
+          iterations: 10000,
+          storage: mockStorage,
+        });
+
+        expect(storage.stats().iterations).toBe(10000);
+        storage.destroy();
+      });
+    });
+
+    describe('isValidEntry / get error codes', () => {
+      async function expectGetCode(
+        prefix: string,
+        rawValue: string,
+        expectedCode: string
+      ): Promise<void> {
+        const storage = await EncryptedStorage.create({
+          password: 'secure-password-123',
+          prefix,
+          storage: mockStorage,
+        });
+        mockStorage.setItem(`${prefix}.entry`, rawValue);
+
+        let caught: unknown = null;
+        try {
+          await storage.get('entry');
+        } catch (error) {
+          caught = error;
+        } finally {
+          storage.destroy();
+        }
+
+        expect(caught).toBeInstanceOf(EncryptionError);
+        expect((caught as EncryptionError).code).toBe(expectedCode);
+      }
+
+      it('should report INVALID_DATA_FORMAT (not DECRYPTION_FAILED) for a null entry', async () => {
+        await expectGetCode('mhNull', 'null', 'INVALID_DATA_FORMAT');
+      });
+
+      it('should report INVALID_DATA_FORMAT for a primitive string entry', async () => {
+        await expectGetCode('mhString', '"just a string"', 'INVALID_DATA_FORMAT');
+      });
+
+      it('should report INVALID_DATA_FORMAT for an entry missing iv', async () => {
+        await expectGetCode(
+          'mhNoIv',
+          JSON.stringify({ data: 'b', timestamp: 0 }),
+          'INVALID_DATA_FORMAT'
+        );
+      });
+
+      it('should report INVALID_DATA_FORMAT for an entry missing data', async () => {
+        await expectGetCode(
+          'mhNoData',
+          JSON.stringify({ iv: 'a', timestamp: 0 }),
+          'INVALID_DATA_FORMAT'
+        );
+      });
+
+      it('should report INVALID_DATA_FORMAT for an entry missing timestamp', async () => {
+        await expectGetCode(
+          'mhNoTs',
+          JSON.stringify({ iv: 'a', data: 'b' }),
+          'INVALID_DATA_FORMAT'
+        );
+      });
+
+      it('should report INVALID_DATA_FORMAT for an entry whose timestamp is not a number', async () => {
+        await expectGetCode(
+          'mhBadTs',
+          JSON.stringify({ iv: 'a', data: 'b', timestamp: '0' }),
+          'INVALID_DATA_FORMAT'
+        );
+      });
+    });
+
+    describe('isQuotaError detection', () => {
+      async function setItemThrows(thrown: unknown): Promise<EncryptionError> {
+        const quotaStorage = createMockLocalStorage();
+        vi.spyOn(quotaStorage, 'setItem').mockImplementation((key) => {
+          if (!key.endsWith('__salt__')) {
+            throw thrown;
+          }
+        });
+
+        const storage = await EncryptedStorage.create({
+          password: 'secure-password-123',
+          storage: quotaStorage,
+        });
+
+        let caught: unknown = null;
+        try {
+          await storage.set('key', 'value');
+        } catch (error) {
+          caught = error;
+        } finally {
+          storage.destroy();
+        }
+
+        expect(caught).toBeInstanceOf(EncryptionError);
+        return caught as EncryptionError;
+      }
+
+      it('should detect quota via QuotaExceededError name even without "quota" in the message', async () => {
+        const error = new Error('disk is full');
+        error.name = 'QuotaExceededError';
+
+        const result = await setItemThrows(error);
+        expect(result.code).toBe('STORAGE_QUOTA_EXCEEDED');
+      });
+
+      it('should detect quota via NS_ERROR_DOM_QUOTA_REACHED name even without "quota" in the message', async () => {
+        const error = new Error('storage is full');
+        error.name = 'NS_ERROR_DOM_QUOTA_REACHED';
+
+        const result = await setItemThrows(error);
+        expect(result.code).toBe('STORAGE_QUOTA_EXCEEDED');
+      });
+
+      it('should detect quota via the message when the name does not match', async () => {
+        const error = new Error('The quota has been exceeded');
+        error.name = 'SomeOtherError';
+
+        const result = await setItemThrows(error);
+        expect(result.code).toBe('STORAGE_QUOTA_EXCEEDED');
+      });
+
+      it('should NOT treat a non-Error quota-shaped object as a quota error', async () => {
+        // A plain object that quacks like a quota error must be rejected by the
+        // `instanceof Error` guard and surface as a generic ENCRYPTION_FAILED.
+        const result = await setItemThrows({
+          name: 'QuotaExceededError',
+          message: 'quota exceeded',
+        });
+        expect(result.code).toBe('ENCRYPTION_FAILED');
+      });
+    });
+
+    describe('clear / keys prefix and null-key filtering', () => {
+      /**
+       * Build a storage whose `key(index)` returns `null` for one in-range
+       * index, simulating a sparse/contractually-odd Storage. Exercises the
+       * `key !== null` guards in clear() and keys().
+       */
+      function createNullHoleStorage(entries: ReadonlyArray<[string, string]>): Storage {
+        const store = new Map<string, string>(entries);
+        const orderedKeys: (string | null)[] = [null, ...store.keys()];
+
+        return {
+          get length() {
+            return orderedKeys.length;
+          },
+          clear(): void {
+            store.clear();
+          },
+          getItem(key: string): string | null {
+            return store.get(key) ?? null;
+          },
+          key(index: number): string | null {
+            return orderedKeys[index] ?? null;
+          },
+          removeItem(key: string): void {
+            store.delete(key);
+          },
+          setItem(key: string, value: string): void {
+            store.set(key, value);
+            if (!orderedKeys.includes(key)) {
+              orderedKeys.push(key);
+            }
+          },
+        };
+      }
+
+      it('clear() should tolerate a null key returned by storage', async () => {
+        const nullHoleStorage = createNullHoleStorage([
+          ['mhClear__salt__', 'c2FsdA=='],
+          ['mhClear.a', '{"iv":"a","data":"b","timestamp":0}'],
+        ]);
+
+        const storage = await EncryptedStorage.create({
+          password: 'secure-password-123',
+          prefix: 'mhClear',
+          storage: nullHoleStorage,
+        });
+
+        expect(() => storage.clear()).not.toThrow();
+        // The prefixed entry is removed; the salt (no dot) is preserved.
+        expect(nullHoleStorage.getItem('mhClear.a')).toBeNull();
+        expect(nullHoleStorage.getItem('mhClear__salt__')).not.toBeNull();
+        storage.destroy();
+      });
+
+      it('keys() should tolerate a null key returned by storage', async () => {
+        const nullHoleStorage = createNullHoleStorage([
+          ['mhKeys__salt__', 'c2FsdA=='],
+          ['mhKeys.a', '{"iv":"a","data":"b","timestamp":0}'],
+        ]);
+
+        const storage = await EncryptedStorage.create({
+          password: 'secure-password-123',
+          prefix: 'mhKeys',
+          storage: nullHoleStorage,
+        });
+
+        let keys: readonly string[] = [];
+        expect(() => {
+          keys = storage.keys();
+        }).not.toThrow();
+        expect(keys).toEqual(['a']);
+        storage.destroy();
+      });
+    });
+  });
 });

--- a/tests/request/RequestInterceptor.test.ts
+++ b/tests/request/RequestInterceptor.test.ts
@@ -1606,6 +1606,13 @@ describe('RequestInterceptor', () => {
           ['192.167.1.1', 'not 192.168'],
           ['169.253.1.1', 'not 169.254'],
           ['1.2.3.4', 'generic public'],
+          // Public addresses that share the *second* octet of a private range
+          // but not the first. These guard the first-octet equality checks: a
+          // mutant that drops the `first === N` test would wrongly block these.
+          ['8.16.0.1', 'second octet 16 but not 172.x (private B range)'],
+          ['8.31.0.1', 'second octet 31 but not 172.x (private B range)'],
+          ['8.168.0.1', 'second octet 168 but not 192.x (private C)'],
+          ['8.254.0.1', 'second octet 254 but not 169.x (link-local)'],
         ])('should allow %s (%s)', async (ip) => {
           const api = RequestInterceptor.create({ blockPrivateIPs: true });
 
@@ -1668,6 +1675,11 @@ describe('RequestInterceptor', () => {
         it.each([
           ['example.com', 'hostname'],
           ['localhost', 'localhost string'],
+          // Looks like a private IP but has trailing non-digit characters, so it
+          // is NOT a valid IPv4 literal. Guards the trailing `$` anchor of the
+          // IPv4 pattern: without it the prefix "10.0.0.1" would match and the
+          // host would be wrongly blocked.
+          ['10.0.0.1x', 'private-IP prefix with trailing junk (not an IP literal)'],
         ])('should allow %s (%s)', async (host) => {
           const api = RequestInterceptor.create({ blockPrivateIPs: true });
 


### PR DESCRIPTION
## Summary

Hardens the test suites of the security-critical modules against surviving
Stryker mutants. Per the agreed scope, this targets **meaningful logic and
structural mutants** (conditionals, logical/equality operators, regex, error
field identifiers) and deliberately leaves low-value string-literal/message
mutants and provably equivalent mutants alone.

## Mutation score per module (scoped to request / encryption / sanitize / cookie)

| File | Before | After |
| --- | --- | --- |
| EncryptedStorage.ts | 78.7% | **91.1%** |
| CookieOptions.ts | 91.2% | **96.7%** |
| RequestValidation.ts | 78.5% | **80.1%** |
| RequestInterceptor.ts | 93.3% | 93.3% |
| RequestMiddleware.ts | 96.0% | 96.0% |
| StreamProgress.ts | 94.1% | 94.1% |
| RequestAuth.ts | 100% | 100% |
| **combined** | **84.67%** | **89.78%** |

## What changed (tests only — no `src/` changes)

- **EncryptedStorage** (+16 tests): `isValidEntry` per-field type checks,
  `isQuotaError` detection for each quota signal, password-strength boundaries,
  and the prefix-filter loops in `clear()`/`keys()`.
- **CookieOptions** (+5 tests): pin `toAttributeString()` output (kills a seeded
  array element) and assert the `ValidationError.field` identifier for invalid
  path/domain inputs.
- **RequestValidation / SSRF** (+5 tests, in `RequestInterceptor.test.ts`):
  public-IP allow cases that share a second octet with the private 172/192/169
  ranges, plus a trailing-anchor regex case.

## Equivalent / out-of-scope survivors (documented, intentionally not chased)

- **RequestValidation** stays at ~80%: most remaining survivors are equivalent —
  `new URL()` normalizes hostnames before `isPrivateIPv4` runs (so the leading-`^`
  regex and expanded-IPv6 literal branches are unreachable via the public API),
  and the octet/group guards are already `/* v8 ignore */`-marked (#97).
- A few **string-literal/message** mutants (e.g. the human-readable `constraint`
  description text) are left alone — killing them would require brittle
  exact-wording assertions.
- One **CookieOptions** `expires` conditional is a true equivalent mutant (the
  inner ternary resolves to `undefined` either way).

## Follow-up

`src/sanitize/HtmlSanitizer.ts` reports a mutation score of **n/a** (Stryker
instruments it but maps 0 tests per mutant). This is a Stryker/vitest-runner
discovery quirk, not a missing-tests gap — tracked in #154.

## Verification

- [x] `pnpm test` — 4605 passing
- [x] Scoped Stryker re-run — combined 89.78% (above break threshold 85)
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm format:check` — clean
- [x] No IDE inspection warnings (replaced throw-in-try negative-test pattern)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
