### PR TITLE
docs: refresh README lists and fix stale API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tree-shakeable, and fully tested.
 - **Secure by default** — cryptographic randomness, input validation, XSS
   prevention
 - **Dual error handling** — throwing and Result-based APIs
-- **Quality-backed** — 4250+ tests, strict ESLint, full coverage
+- **Quality-backed** — 4600+ tests, strict ESLint, 99%+ coverage
 
 ## Modules
 
@@ -181,29 +181,32 @@ const cleanup = IntersectionObserverWrapper.lazyLoad(
 
 | Module                                      | Module                                        |
 | ------------------------------------------- | --------------------------------------------- |
-| [a11y](documentation/a11y.md)               | [intl](documentation/intl.md)                 |
-| [broadcast](documentation/broadcast.md)     | [keyboard](documentation/keyboard.md)         |
-| [cache](documentation/cache.md)             | [logging](documentation/logging.md)           |
-| [clipboard](documentation/clipboard.md)     | [media](documentation/media.md)               |
-| [color](documentation/color.md)             | [network](documentation/network.md)           |
-| [cookie](documentation/cookie.md)           | [notification](documentation/notification.md) |
-| [core](documentation/core.md)               | [observe](documentation/observe.md)           |
-| [csp](documentation/csp.md)                 | [offline](documentation/offline.md)           |
-| [device](documentation/device.md)           | [performance](documentation/performance.md)   |
-| [download](documentation/download.md)       | [request](documentation/request.md)           |
-| [encryption](documentation/encryption.md)   | [sanitize](documentation/sanitize.md)         |
-| [events](documentation/events.md)           | [scroll](documentation/scroll.md)             |
-| [features](documentation/features.md)       | [session](documentation/session.md)           |
-| [focus](documentation/focus.md)             | [storage](documentation/storage.md)           |
-| [form](documentation/form.md)               | [url](documentation/url.md)                   |
-| [fullscreen](documentation/fullscreen.md)   | [visibility](documentation/visibility.md)     |
-| [geolocation](documentation/geolocation.md) | [websocket](documentation/websocket.md)       |
+| [a11y](documentation/a11y.md)               | [indexeddb](documentation/indexeddb.md)       |
+| [broadcast](documentation/broadcast.md)     | [intl](documentation/intl.md)                 |
+| [cache](documentation/cache.md)             | [keyboard](documentation/keyboard.md)         |
+| [clipboard](documentation/clipboard.md)     | [logging](documentation/logging.md)           |
+| [color](documentation/color.md)             | [media](documentation/media.md)               |
+| [cookie](documentation/cookie.md)           | [network](documentation/network.md)           |
+| [core](documentation/core.md)               | [notification](documentation/notification.md) |
+| [csp](documentation/csp.md)                 | [observe](documentation/observe.md)           |
+| [device](documentation/device.md)           | [offline](documentation/offline.md)           |
+| [download](documentation/download.md)       | [performance](documentation/performance.md)   |
+| [encryption](documentation/encryption.md)   | [request](documentation/request.md)           |
+| [events](documentation/events.md)           | [sanitize](documentation/sanitize.md)         |
+| [features](documentation/features.md)       | [scroll](documentation/scroll.md)             |
+| [focus](documentation/focus.md)             | [session](documentation/session.md)           |
+| [form](documentation/form.md)               | [storage](documentation/storage.md)           |
+| [fullscreen](documentation/fullscreen.md)   | [url](documentation/url.md)                   |
+| [geolocation](documentation/geolocation.md) | [visibility](documentation/visibility.md)     |
+| [html](documentation/html.md)               | [websocket](documentation/websocket.md)       |
 | [idle](documentation/idle.md)               | [glossary](documentation/glossary.md)         |
 
 **Recipes:** [Offline-First App](documentation/recipes/offline-first-app.md) ·
 [Secure File Upload](documentation/recipes/secure-file-upload.md) ·
 [Accessible Form](documentation/recipes/accessible-form.md) ·
-[Resilient API Client](documentation/recipes/resilient-api-client.md)
+[Resilient API Client](documentation/recipes/resilient-api-client.md) ·
+[Real-Time Data Sync](documentation/recipes/real-time-data-sync.md) ·
+[Progressive Enhancement](documentation/recipes/progressive-enhancement.md)
 
 **Guides:** [Browser Support](documentation/browser-support.md) ·
 [Error Handling](documentation/error-handling.md) ·

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -129,7 +129,7 @@ const debouncedSearch = debounce(handleSearch, 300);
 const throttledScroll = throttle(handleScroll, 100);
 
 // Feature detection
-if (FeatureDetect.hasClipboard()) {
+if (FeatureDetect.clipboard()) {
   await ClipboardManager.writeText('Hello!');
 }
 

--- a/documentation/recipes/offline-first-app.md
+++ b/documentation/recipes/offline-first-app.md
@@ -121,14 +121,12 @@ const ws = WebSocketManager.create({
   url: 'wss://chat.example.com/ws',
   reconnect: true,
   maxReconnectAttempts: 20,
-  reconnectInterval: 1000,
-  maxReconnectInterval: 30_000,
+  reconnectDelay: 1000,
+  maxReconnectDelay: 30_000,
   queueMessages: true,
 });
 
-ws.onMessage(async (data) => {
-  const event = JSON.parse(data as string);
-
+ws.onMessage<{ type: string; payload: Message }>(async (event) => {
   if (event.type === 'message') {
     const msg: Message = event.payload;
 
@@ -201,8 +199,7 @@ async function createChatService() {
   });
 
   // Incoming server messages update local stores
-  ws.onMessage(async (data) => {
-    const event = JSON.parse(data as string);
+  ws.onMessage<{ type: string; payload: Message }>(async (event) => {
     if (event.type === 'message') {
       await db.put('messages', event.payload);
       await cache.delete(`channel:${event.payload.channel}`);
@@ -253,7 +250,7 @@ async function createChatService() {
 
     /** Tear down all resources. */
     destroy(): void {
-      ws.disconnect();
+      ws.close();
       queue.destroy();
       cache.destroy();
       db.close();
@@ -285,7 +282,7 @@ references:
 ```typescript
 function destroy(): void {
   // 1. Stop receiving data
-  ws.disconnect();
+  ws.close();
 
   // 2. Stop processing queued items
   queue.destroy();


### PR DESCRIPTION
## Summary

Follow-up to #99 and #100 — brings the docs surface back in sync and fixes stale
API references in code examples.

**README**
- Add the missing `html` and `indexeddb` module-doc links (all 37 modules now listed).
- Add the two new recipes (Real-Time Data Sync, Progressive Enhancement).
- Bump test count `4250+` → `4600+` (actual: 4605), correct `full coverage` →
  `99%+ coverage` (thresholds: lines/functions/statements 99, branches 95).

**Stale API fixes in examples** (verified against `src/`)
- `documentation/index.md`: `FeatureDetect.hasClipboard()` → `clipboard()`.
- `documentation/recipes/offline-first-app.md`:
  - `reconnectInterval`/`maxReconnectInterval` → `reconnectDelay`/`maxReconnectDelay`
  - `ws.disconnect()` → `ws.close()`
  - drop the `onMessage` double-parse — `onMessage<T>` already delivers parsed JSON,
    so `JSON.parse(data as string)` on the (already-parsed) object would throw.

## Verification

- [x] All referenced APIs checked against `src/` (WebSocketManager, FeatureDetect)
- [x] `prettier --check` clean; `markdownlint-cli2` — 0 errors
- [x] Documentation-only; no source or test files touched