### PR TITLE
chore(deps): override dompurify and markdown-it to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,16 @@ overrides:
   qs: '>=6.15.2'
   js-yaml: '>=4.2.0'
   '@babel/core': '>=7.29.1'
+  dompurify: '>=3.4.9'
+  markdown-it: '>=14.1.2'
 
 importers:
 
   .:
     dependencies:
       dompurify:
-        specifier: '>=3.0.0'
-        version: 3.4.0
+        specifier: '>=3.4.9'
+        version: 3.4.10
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.3
@@ -1900,8 +1902,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2667,8 +2669,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   lint-staged@17.0.7:
     resolution: {integrity: sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==}
@@ -2723,8 +2725,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdownlint-cli2-formatter-default@0.0.6:
@@ -5782,7 +5784,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6553,7 +6555,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -6618,11 +6620,11 @@ snapshots:
     dependencies:
       semver: 7.8.4
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -6637,7 +6639,7 @@ snapshots:
       js-yaml: 4.2.0
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
       micromatch: 4.0.8
@@ -7599,7 +7601,7 @@ snapshots:
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       minimatch: 10.2.5
       typescript: 6.0.3
       yaml: 2.8.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ overrides:
   qs: '>=6.15.2'
   js-yaml: '>=4.2.0'
   '@babel/core': '>=7.29.1'
+  dompurify: '>=3.4.9'
+  markdown-it: '>=14.1.2'
 
 allowBuilds:
   esbuild: false


### PR DESCRIPTION
## Summary

Adds pnpm overrides to pull patched versions of two dependencies flagged by `pnpm audit`, clearing the `--prod --audit-level=moderate` gate (run by the pre-push hook and CI).

## Changes

- **`dompurify` → `>=3.4.9`** (resolves to 3.4.10). Declared as a `peerDependency` (`>=3.0.0`), the dev-installed copy was pinned at 3.4.0. The peer range is intentionally left untouched so consumers keep their flexibility; the override only patches the dev-installed/audited copy. Clears GHSA-rp9w-3fw7-7cwq, GHSA-vxr8-fq34-vvx9, GHSA-gvmj-g25r-r7wr, GHSA-76mc-f452-cxcm, GHSA-x4vx-rjvf-j5p4 and others.
- **`markdown-it` → `>=14.1.2`** (resolves to 14.2.0). Transitive via `markdownlint-cli2`; clears GHSA-6v5v-wf23-fmfq.

Follows the existing override pattern in `pnpm-workspace.yaml` (cf. #162).

## Why overrides rather than a plain update

- `markdown-it` is transitive (controlled by `markdownlint-cli2`), so a top-level update cannot bump it.
- `dompurify` is a peer dependency with no manifest entry to update directly; the override pins the resolution explicitly and prevents regression.

## Verification

- [x] `pnpm audit --prod --audit-level=moderate` → no known vulnerabilities (exit 0)
- [x] `pnpm audit` (full) → no known vulnerabilities
- [x] pre-push quality gate passes (format, lint, typecheck, tests, build, size, audit)