### PR TITLE
feat(keyboard): make ShortcutManager adoptable as an app-wide shortcut surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,24 @@ const user = storage.get('user-1');
 ### Keyboard Shortcuts
 
 ```typescript
-import { ShortcutManager } from '@zappzarapp/browser-utils/keyboard';
+import {
+  ShortcutManager,
+  KeyboardShortcut,
+} from '@zappzarapp/browser-utils/keyboard';
 
-const shortcuts = ShortcutManager.create();
+// Single shortcut — returns a cleanup function
+const cleanup = ShortcutManager.on(KeyboardShortcut.ctrlKey('s'), () =>
+  saveDocument()
+);
 
-shortcuts.register({
-  key: 's',
-  ctrlKey: true,
-  handler: () => saveDocument(),
-});
+// App-wide surface: bare keys skipped while typing, one undo/redo per platform
+const shortcuts = ShortcutManager.createGroup({ ignoreEditableTargets: true });
+shortcuts
+  .add(KeyboardShortcut.cmdOrCtrl('z'), undo)
+  .add(KeyboardShortcut.key('r'), () => (hasSelection() ? rotate() : false));
 
-shortcuts.destroy();
+cleanup();
+shortcuts.cleanup();
 ```
 
 ### Network Retry Queue

--- a/documentation/keyboard.md
+++ b/documentation/keyboard.md
@@ -31,6 +31,7 @@ cleanup();
 | `ShortcutGroup`          | Group shortcuts for bulk management      |
 | `ShortcutDefinition`     | Interface for shortcut configuration     |
 | `ShortcutHandlerOptions` | Options for shortcut handlers            |
+| `ShortcutHandler`        | Handler function type                    |
 | `CleanupFn`              | Cleanup function type                    |
 
 ## KeyboardShortcut
@@ -55,6 +56,10 @@ const altH = KeyboardShortcut.altKey('h');
 // Meta + Key (Cmd on Mac)
 const metaK = KeyboardShortcut.metaKey('k');
 
+// Ctrl OR Cmd + Key — one registration for cross-platform actions
+const undo = KeyboardShortcut.cmdOrCtrl('z');
+const redo = KeyboardShortcut.cmdOrCtrlShift('z');
+
 // Common shortcuts
 const escape = KeyboardShortcut.escape();
 const enter = KeyboardShortcut.enter();
@@ -69,13 +74,18 @@ const custom = KeyboardShortcut.create({
 
 ### ShortcutDefinition
 
-| Property   | Type      | Default  | Description                     |
-| ---------- | --------- | -------- | ------------------------------- |
-| `key`      | `string`  | Required | Key to match (case-insensitive) |
-| `ctrlKey`  | `boolean` | `false`  | Require Ctrl key                |
-| `shiftKey` | `boolean` | `false`  | Require Shift key               |
-| `altKey`   | `boolean` | `false`  | Require Alt key                 |
-| `metaKey`  | `boolean` | `false`  | Require Meta key (Cmd on Mac)   |
+| Property    | Type      | Default  | Description                                                |
+| ----------- | --------- | -------- | ---------------------------------------------------------- |
+| `key`       | `string`  | Required | Key to match (case-insensitive)                            |
+| `ctrlKey`   | `boolean` | `false`  | Require Ctrl key                                           |
+| `shiftKey`  | `boolean` | `false`  | Require Shift key                                          |
+| `altKey`    | `boolean` | `false`  | Require Alt key                                            |
+| `metaKey`   | `boolean` | `false`  | Require Meta key (Cmd on Mac)                              |
+| `cmdOrCtrl` | `boolean` | `false`  | Match either Ctrl or Meta (supersedes `ctrlKey`/`metaKey`) |
+
+Modifier matching is **exact**: `ctrlKey('z')` does not fire on `Ctrl+Shift+Z`.
+With `cmdOrCtrl`, exactly one of Ctrl/Meta must be held (holding both does not
+match), while `shiftKey`/`altKey` remain exact.
 
 ### Display Methods
 
@@ -84,6 +94,12 @@ const shortcut = KeyboardShortcut.ctrlShift('s');
 
 shortcut.toString(); // "Ctrl+Shift+S"
 shortcut.toMacString(); // "⌃⇧S"
+
+// cmdOrCtrl renders per platform flavor: Ctrl for toString, Cmd for toMacString.
+// Pick the method by platform (e.g. via DeviceInfo) when displaying it.
+const undo = KeyboardShortcut.cmdOrCtrl('z');
+undo.toString(); // "Ctrl+Z"
+undo.toMacString(); // "⌘Z"
 ```
 
 ### Matching Events
@@ -100,13 +116,64 @@ document.addEventListener('keydown', (event) => {
 
 ### Handler Options
 
-| Option                     | Type      | Default | Description                        |
-| -------------------------- | --------- | ------- | ---------------------------------- |
-| `preventDefault`           | `boolean` | `true`  | Prevent default browser behavior   |
-| `stopPropagation`          | `boolean` | `false` | Stop event propagation             |
-| `stopImmediatePropagation` | `boolean` | `false` | Stop immediate propagation         |
-| `capture`                  | `boolean` | `false` | Use capture phase                  |
-| `once`                     | `boolean` | `false` | Remove handler after first trigger |
+| Option                     | Type      | Default | Description                                             |
+| -------------------------- | --------- | ------- | ------------------------------------------------------- |
+| `preventDefault`           | `boolean` | `true`  | Prevent default browser behavior                        |
+| `stopPropagation`          | `boolean` | `false` | Stop event propagation                                  |
+| `stopImmediatePropagation` | `boolean` | `false` | Stop immediate propagation                              |
+| `capture`                  | `boolean` | `false` | Use capture phase                                       |
+| `once`                     | `boolean` | `false` | Remove handler after first trigger                      |
+| `ignoreEditableTargets`    | `boolean` | `false` | Skip the shortcut while focus is in an editable element |
+
+### Handler Contract
+
+A handler receives the originating `KeyboardEvent` and may return a value:
+
+```typescript
+type ShortcutHandler = (event: KeyboardEvent) => unknown;
+```
+
+The handler runs **before** `preventDefault`. Return `false` to **decline** the
+key — the manager then skips `preventDefault`/`stopPropagation`, leaves the
+event for other listeners, and (with `once`) keeps the handler registered. Any
+other return value (including `undefined`) consumes the key per the options.
+This makes conditional shortcuts first-class:
+
+```typescript
+// Rotate only when something is selected; otherwise let the key through.
+ShortcutManager.on(KeyboardShortcut.key('r'), () => {
+  if (!hasSelection()) return false; // decline — no preventDefault
+  rotateSelection();
+});
+```
+
+> Because the handler runs first, a handler that throws skips `preventDefault`
+> and `once` cleanup.
+
+### Editable-Target Skip
+
+By default a `document`-bound shortcut fires regardless of focus. For app-wide
+bare-key shortcuts (`R`, `Delete`) that must not fire while the user is typing,
+enable `ignoreEditableTargets`. The shortcut is then skipped (no handler, no
+`preventDefault`) when the event target is an `<input>`, `<textarea>`,
+`<select>`, or an element inside a `[contenteditable]` host (nested elements
+included; `contenteditable="false"` does not count):
+
+```typescript
+ShortcutManager.on(KeyboardShortcut.key('r'), rotate, {
+  ignoreEditableTargets: true,
+});
+```
+
+> Defaults to `false` to stay non-breaking and to keep modifier shortcuts like
+> `Ctrl+S` and `Escape`-to-close working while focus is in a field. For an
+> app-wide surface, enable it once via a group default (see below) rather than
+> per shortcut.
+>
+> **Known limitation:** detection reads `event.target`, which the browser
+> retargets to the shadow host for events crossing an open Shadow DOM boundary.
+> A shortcut may therefore still fire while typing in an `<input>` nested inside
+> a web component's shadow root.
 
 ### ShortcutManager.on()
 
@@ -176,6 +243,23 @@ group.cleanup();
 group.size;
 ```
 
+### Group Default Options
+
+Pass default options to `createGroup` to apply them to every shortcut added via
+`add` (per-`add` options take precedence). Use this to opt an app-wide surface
+into `ignoreEditableTargets` once instead of per shortcut:
+
+```typescript
+const group = ShortcutManager.createGroup({ ignoreEditableTargets: true });
+
+group
+  .add(KeyboardShortcut.key('r'), rotate) // skipped while typing
+  .add(KeyboardShortcut.key('Delete'), deleteSelection); // skipped while typing
+```
+
+> `addEscape` is intentionally exempt from the group defaults, so `Escape` still
+> fires while focus is in an input — the common "close modal while typing" case.
+
 ## Usage Examples
 
 ### Modal Dialog Shortcuts
@@ -207,6 +291,34 @@ ShortcutManager.on(KeyboardShortcut.ctrlKey('s'), save);
 ShortcutManager.on(KeyboardShortcut.ctrlKey('z'), undo);
 ShortcutManager.on(KeyboardShortcut.ctrlShift('z'), redo);
 ShortcutManager.on(KeyboardShortcut.key('F1'), showHelp);
+```
+
+### App-Wide Editing Shortcuts
+
+A `document`-bound surface for global editing shortcuts: bare keys are skipped
+while typing, conditional handlers decline when there is nothing to act on, and
+`cmdOrCtrl` covers undo/redo on every platform with one registration each.
+
+```typescript
+const shortcuts = ShortcutManager.createGroup({ ignoreEditableTargets: true });
+
+shortcuts
+  .add(KeyboardShortcut.cmdOrCtrl('z'), undo)
+  .add(KeyboardShortcut.cmdOrCtrlShift('z'), redo)
+  .add(KeyboardShortcut.key('Delete'), () => {
+    if (!hasSelection()) return false; // decline — let the key through
+    deleteSelection();
+  })
+  .add(KeyboardShortcut.key('r'), () => {
+    if (!hasSelection()) return false;
+    rotateSelection();
+  });
+
+// Escape stays active even while typing (not subject to the group default).
+shortcuts.addEscape(cancelDrag);
+
+// Tear down the whole surface at once.
+shortcuts.cleanup();
 ```
 
 ### One-Time Shortcut

--- a/src/keyboard/KeyboardShortcut.ts
+++ b/src/keyboard/KeyboardShortcut.ts
@@ -35,6 +35,11 @@ export interface ShortcutDefinition {
   readonly altKey?: boolean;
   /** Require Meta key (Cmd on Mac) */
   readonly metaKey?: boolean;
+  /**
+   * Match when **either** Ctrl or Meta is held (other modifiers still exact).
+   * Supersedes `ctrlKey`/`metaKey`. Express "Cmd-or-Ctrl+Z" with one shortcut.
+   */
+  readonly cmdOrCtrl?: boolean;
 }
 
 export class KeyboardShortcut {
@@ -43,6 +48,7 @@ export class KeyboardShortcut {
   readonly shiftKey: boolean;
   readonly altKey: boolean;
   readonly metaKey: boolean;
+  readonly cmdOrCtrl: boolean;
 
   private constructor(def: Required<ShortcutDefinition>) {
     this.key = def.key;
@@ -50,6 +56,7 @@ export class KeyboardShortcut {
     this.shiftKey = def.shiftKey;
     this.altKey = def.altKey;
     this.metaKey = def.metaKey;
+    this.cmdOrCtrl = def.cmdOrCtrl;
   }
 
   // =========================================================================
@@ -60,12 +67,15 @@ export class KeyboardShortcut {
    * Create a custom shortcut.
    */
   static create(def: ShortcutDefinition): KeyboardShortcut {
+    const cmdOrCtrl = def.cmdOrCtrl ?? false;
     return new KeyboardShortcut({
       key: def.key,
-      ctrlKey: def.ctrlKey ?? false,
+      // cmdOrCtrl supersedes ctrlKey/metaKey; force them off to keep state consistent.
+      ctrlKey: cmdOrCtrl ? false : (def.ctrlKey ?? false),
       shiftKey: def.shiftKey ?? false,
       altKey: def.altKey ?? false,
-      metaKey: def.metaKey ?? false,
+      metaKey: cmdOrCtrl ? false : (def.metaKey ?? false),
+      cmdOrCtrl,
     });
   }
 
@@ -105,6 +115,22 @@ export class KeyboardShortcut {
   }
 
   /**
+   * Create a shortcut that matches Ctrl+Key **or** Cmd+Key.
+   * One registration for cross-platform actions like undo (`cmdOrCtrl('z')`).
+   */
+  static cmdOrCtrl(key: string): KeyboardShortcut {
+    return KeyboardShortcut.create({ key, cmdOrCtrl: true });
+  }
+
+  /**
+   * Create a shortcut that matches Ctrl+Shift+Key **or** Cmd+Shift+Key.
+   * One registration for actions like redo (`cmdOrCtrlShift('z')`).
+   */
+  static cmdOrCtrlShift(key: string): KeyboardShortcut {
+    return KeyboardShortcut.create({ key, cmdOrCtrl: true, shiftKey: true });
+  }
+
+  /**
    * Create Escape key shortcut.
    */
   static escape(): KeyboardShortcut {
@@ -132,6 +158,17 @@ export class KeyboardShortcut {
         ? event.key.toUpperCase() === this.key.toUpperCase()
         : event.key === this.key;
 
+    if (this.cmdOrCtrl) {
+      // Exactly one of Ctrl/Meta — holding both is a different chord and must not
+      // match, preserving the library's exact-modifier guarantee.
+      return (
+        keyMatches &&
+        event.ctrlKey !== event.metaKey &&
+        event.shiftKey === this.shiftKey &&
+        event.altKey === this.altKey
+      );
+    }
+
     return (
       keyMatches &&
       event.ctrlKey === this.ctrlKey &&
@@ -151,7 +188,8 @@ export class KeyboardShortcut {
   toString(): string {
     const parts: string[] = [];
 
-    if (this.ctrlKey) {
+    // cmdOrCtrl renders in this method's non-Mac flavor (Ctrl); toMacString shows Cmd.
+    if (this.ctrlKey || this.cmdOrCtrl) {
       parts.push('Ctrl');
     }
     if (this.altKey) {
@@ -184,7 +222,8 @@ export class KeyboardShortcut {
     if (this.shiftKey) {
       parts.push('⇧');
     }
-    if (this.metaKey) {
+    // cmdOrCtrl renders as Cmd in the Mac flavor; toString shows Ctrl.
+    if (this.metaKey || this.cmdOrCtrl) {
       parts.push('⌘');
     }
 

--- a/src/keyboard/ShortcutManager.ts
+++ b/src/keyboard/ShortcutManager.ts
@@ -24,6 +24,44 @@
 import { KeyboardShortcut, type ShortcutDefinition } from './KeyboardShortcut.js';
 
 /**
+ * Shortcut handler.
+ *
+ * Receives the originating {@link KeyboardEvent}. Return `false` to decline the
+ * key: the manager then skips `preventDefault`/`stopPropagation`, leaves the
+ * event for other listeners, and (with `once`) keeps the handler registered —
+ * the shortcut behaves as if it had not matched this time. Any other return
+ * value (incl. `undefined`) consumes the key per the handler options.
+ *
+ * The return type is `unknown` rather than `void | boolean` so existing
+ * value-returning handlers (e.g. `async`/Promise-returning) stay assignable;
+ * only a literal `false` declines.
+ */
+export type ShortcutHandler = (event: KeyboardEvent) => unknown;
+
+/**
+ * Determine whether an event target is an editable element: `<input>`,
+ * `<textarea>`, `<select>`, or an element inside a `[contenteditable]` host
+ * (nested elements included; `contenteditable="false"` does not count).
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  // Element (not HTMLElement) so e.g. an SVG inside a contenteditable host counts.
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const tag = target.tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true;
+  }
+
+  // contenteditable is an enumerated attribute; its value is case-insensitive.
+  const editableHost = target.closest('[contenteditable]');
+  return (
+    editableHost !== null && editableHost.getAttribute('contenteditable')?.toLowerCase() !== 'false'
+  );
+}
+
+/**
  * Options for shortcut handlers.
  */
 export interface ShortcutHandlerOptions {
@@ -56,6 +94,15 @@ export interface ShortcutHandlerOptions {
    * @default false
    */
   readonly once?: boolean;
+
+  /**
+   * Skip the shortcut when the event target is an editable element
+   * (`<input>`, `<textarea>`, `<select>`, or a `[contenteditable]` host incl.
+   * nested elements). The handler is not called and the key is left untouched.
+   * Enable this for app-wide bare-key shortcuts so they don't fire while typing.
+   * @default false
+   */
+  readonly ignoreEditableTargets?: boolean;
 }
 
 import type { CleanupFn } from '../core/index.js';
@@ -71,7 +118,7 @@ export const ShortcutManager = {
    */
   on(
     shortcut: KeyboardShortcut | ShortcutDefinition,
-    handler: () => void,
+    handler: ShortcutHandler,
     options: ShortcutHandlerOptions = {}
   ): CleanupFn {
     const kbd = shortcut instanceof KeyboardShortcut ? shortcut : KeyboardShortcut.create(shortcut);
@@ -82,12 +129,21 @@ export const ShortcutManager = {
       stopImmediatePropagation = false,
       capture = false,
       once = false,
+      ignoreEditableTargets = false,
     } = options;
 
     let isActive = true;
 
     const listener = (event: KeyboardEvent): void => {
       if (!isActive || !kbd.matches(event)) {
+        return;
+      }
+      if (ignoreEditableTargets && isEditableTarget(event.target)) {
+        return;
+      }
+
+      // Run the handler first so it can decline the key by returning false.
+      if (handler(event) === false) {
         return;
       }
 
@@ -100,8 +156,6 @@ export const ShortcutManager = {
       if (stopImmediatePropagation) {
         event.stopImmediatePropagation();
       }
-
-      handler();
 
       if (once) {
         cleanup();
@@ -125,7 +179,7 @@ export const ShortcutManager = {
    * @param handler - Function to call when Escape is pressed
    * @returns Cleanup function
    */
-  onEscape(handler: () => void): CleanupFn {
+  onEscape(handler: ShortcutHandler): CleanupFn {
     return ShortcutManager.on(KeyboardShortcut.escape(), handler, {
       capture: true,
       stopImmediatePropagation: true,
@@ -140,25 +194,29 @@ export const ShortcutManager = {
    * @param options - Handler options
    * @returns Cleanup function
    */
-  onEnter(handler: () => void, options: ShortcutHandlerOptions = {}): CleanupFn {
+  onEnter(handler: ShortcutHandler, options: ShortcutHandlerOptions = {}): CleanupFn {
     return ShortcutManager.on(KeyboardShortcut.enter(), handler, options);
   },
 
   /**
    * Create a handler group for easy bulk cleanup.
    *
+   * Pass `defaultOptions` to apply them to every shortcut added to the group
+   * (per-`add` options take precedence). Use this to opt an app-wide shortcut
+   * surface into editable-target skipping once instead of per shortcut.
+   *
    * @example
    * ```TypeScript
-   * const group = ShortcutManager.createGroup();
-   * group.add(KeyboardShortcut.escape(), closeModal);
+   * const group = ShortcutManager.createGroup({ ignoreEditableTargets: true });
+   * group.add(KeyboardShortcut.key('r'), rotate);   // skipped while typing
    * group.add(KeyboardShortcut.ctrlKey('s'), save);
    *
    * // Later: cleanup all at once
    * group.cleanup();
    * ```
    */
-  createGroup(): ShortcutGroup {
-    return new ShortcutGroup();
+  createGroup(defaultOptions?: ShortcutHandlerOptions): ShortcutGroup {
+    return new ShortcutGroup(defaultOptions);
   },
 };
 
@@ -169,21 +227,32 @@ export class ShortcutGroup {
   private readonly cleanups: CleanupFn[] = [];
 
   /**
-   * Add a shortcut to this group.
+   * @param defaultOptions - Options applied to every {@link add} call
+   *   (per-`add` options take precedence). Does not affect {@link addEscape}.
+   */
+  constructor(private readonly defaultOptions: ShortcutHandlerOptions = {}) {}
+
+  /**
+   * Add a shortcut to this group. Group `defaultOptions` apply unless overridden
+   * by `options`.
    */
   add(
     shortcut: KeyboardShortcut | ShortcutDefinition,
-    handler: () => void,
+    handler: ShortcutHandler,
     options?: ShortcutHandlerOptions
   ): this {
-    this.cleanups.push(ShortcutManager.on(shortcut, handler, options));
+    this.cleanups.push(
+      ShortcutManager.on(shortcut, handler, { ...this.defaultOptions, ...options })
+    );
     return this;
   }
 
   /**
-   * Add an Escape handler to this group.
+   * Add an Escape handler to this group. Deliberately exempt from the group's
+   * `defaultOptions` (e.g. `ignoreEditableTargets`) so Escape still fires while
+   * focus is in an input — the common "close modal while typing" case.
    */
-  addEscape(handler: () => void): this {
+  addEscape(handler: ShortcutHandler): this {
     this.cleanups.push(ShortcutManager.onEscape(handler));
     return this;
   }

--- a/src/keyboard/index.ts
+++ b/src/keyboard/index.ts
@@ -1,4 +1,4 @@
 export { KeyboardShortcut } from './KeyboardShortcut.js';
 export type { ShortcutDefinition } from './KeyboardShortcut.js';
 export { ShortcutManager, ShortcutGroup } from './ShortcutManager.js';
-export type { ShortcutHandlerOptions } from './ShortcutManager.js';
+export type { ShortcutHandlerOptions, ShortcutHandler } from './ShortcutManager.js';

--- a/tests/keyboard/KeyboardShortcut.test.ts
+++ b/tests/keyboard/KeyboardShortcut.test.ts
@@ -113,6 +113,49 @@ describe('KeyboardShortcut', () => {
     });
   });
 
+  describe('cmdOrCtrl', () => {
+    it('should create a Ctrl-or-Cmd shortcut', () => {
+      const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+
+      expect(shortcut.key).toBe('z');
+      expect(shortcut.cmdOrCtrl).toBe(true);
+      expect(shortcut.ctrlKey).toBe(false);
+      expect(shortcut.metaKey).toBe(false);
+      expect(shortcut.shiftKey).toBe(false);
+      expect(shortcut.altKey).toBe(false);
+    });
+
+    it('should force ctrlKey/metaKey off even if passed via create', () => {
+      const shortcut = KeyboardShortcut.create({
+        key: 'z',
+        cmdOrCtrl: true,
+        ctrlKey: true,
+        metaKey: true,
+      });
+
+      expect(shortcut.cmdOrCtrl).toBe(true);
+      expect(shortcut.ctrlKey).toBe(false);
+      expect(shortcut.metaKey).toBe(false);
+    });
+
+    it('should default cmdOrCtrl to false', () => {
+      const shortcut = KeyboardShortcut.key('z');
+
+      expect(shortcut.cmdOrCtrl).toBe(false);
+    });
+  });
+
+  describe('cmdOrCtrlShift', () => {
+    it('should create a Ctrl-or-Cmd + Shift shortcut', () => {
+      const shortcut = KeyboardShortcut.cmdOrCtrlShift('z');
+
+      expect(shortcut.key).toBe('z');
+      expect(shortcut.cmdOrCtrl).toBe(true);
+      expect(shortcut.shiftKey).toBe(true);
+      expect(shortcut.altKey).toBe(false);
+    });
+  });
+
   describe('escape', () => {
     it('should create Escape key shortcut', () => {
       const shortcut = KeyboardShortcut.escape();
@@ -305,6 +348,66 @@ describe('KeyboardShortcut', () => {
 
         expect(shortcut.matches(event)).toBe(true);
       });
+
+      it('should not match Ctrl+Z against Ctrl+Shift+Z (exact modifiers)', () => {
+        const shortcut = KeyboardShortcut.ctrlKey('z');
+        const event = createKeyboardEvent({ key: 'z', ctrlKey: true, shiftKey: true });
+
+        expect(shortcut.matches(event)).toBe(false);
+      });
+    });
+
+    describe('cmdOrCtrl matching', () => {
+      it('should match when Ctrl is held', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z', ctrlKey: true });
+
+        expect(shortcut.matches(event)).toBe(true);
+      });
+
+      it('should match when Meta is held', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z', metaKey: true });
+
+        expect(shortcut.matches(event)).toBe(true);
+      });
+
+      it('should not match when neither Ctrl nor Meta is held', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z' });
+
+        expect(shortcut.matches(event)).toBe(false);
+      });
+
+      it('should respect exact Shift modifier (no Shift required)', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z', ctrlKey: true, shiftKey: true });
+
+        expect(shortcut.matches(event)).toBe(false);
+      });
+
+      it('should match Ctrl+Shift via cmdOrCtrlShift', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrlShift('z');
+        const eventCtrl = createKeyboardEvent({ key: 'z', ctrlKey: true, shiftKey: true });
+        const eventMeta = createKeyboardEvent({ key: 'z', metaKey: true, shiftKey: true });
+
+        expect(shortcut.matches(eventCtrl)).toBe(true);
+        expect(shortcut.matches(eventMeta)).toBe(true);
+      });
+
+      it('should respect exact Alt modifier', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z', ctrlKey: true, altKey: true });
+
+        expect(shortcut.matches(event)).toBe(false);
+      });
+
+      it('should not match when BOTH Ctrl and Meta are held (exactly one)', () => {
+        const shortcut = KeyboardShortcut.cmdOrCtrl('z');
+        const event = createKeyboardEvent({ key: 'z', ctrlKey: true, metaKey: true });
+
+        expect(shortcut.matches(event)).toBe(false);
+      });
     });
   });
 
@@ -384,6 +487,11 @@ describe('KeyboardShortcut', () => {
 
       expect(shortcut.toString()).toBe('Ctrl+F12');
     });
+
+    it('should render cmdOrCtrl in the non-Mac flavor (Ctrl)', () => {
+      expect(KeyboardShortcut.cmdOrCtrl('z').toString()).toBe('Ctrl+Z');
+      expect(KeyboardShortcut.cmdOrCtrlShift('z').toString()).toBe('Ctrl+Shift+Z');
+    });
   });
 
   describe('toMacString', () => {
@@ -445,6 +553,11 @@ describe('KeyboardShortcut', () => {
       const shortcut = KeyboardShortcut.metaKey('F12');
 
       expect(shortcut.toMacString()).toBe('\u2318F12');
+    });
+
+    it('should render cmdOrCtrl in the Mac flavor (Cmd symbol)', () => {
+      expect(KeyboardShortcut.cmdOrCtrl('z').toMacString()).toBe('\u2318Z');
+      expect(KeyboardShortcut.cmdOrCtrlShift('z').toMacString()).toBe('\u21e7\u2318Z');
     });
   });
 

--- a/tests/keyboard/ShortcutManager.test.ts
+++ b/tests/keyboard/ShortcutManager.test.ts
@@ -274,6 +274,242 @@ describe('ShortcutManager', () => {
   });
 
   // ===========================================================================
+  // Editable-target skip
+  // ===========================================================================
+
+  describe('ignoreEditableTargets', () => {
+    function dispatchOn(
+      target: Element,
+      options: { key: string; ctrlKey?: boolean }
+    ): KeyboardEvent {
+      const event = new KeyboardEvent('keydown', {
+        key: options.key,
+        ctrlKey: options.ctrlKey ?? false,
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(event);
+      return event;
+    }
+
+    it('should fire on editable targets when not enabled (default)', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler);
+
+      dispatchOn(input, { key: 'r' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      cleanup();
+      input.remove();
+    });
+
+    it.each(['input', 'textarea', 'select'])(
+      'should skip handler and preventDefault for <%s>',
+      (tag) => {
+        const el = document.createElement(tag);
+        document.body.appendChild(el);
+        const handler = vi.fn();
+        const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+          ignoreEditableTargets: true,
+        });
+
+        const event = dispatchOn(el, { key: 'r' });
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+        cleanup();
+        el.remove();
+      }
+    );
+
+    it('should skip when target is a contenteditable host', () => {
+      const host = document.createElement('div');
+      host.setAttribute('contenteditable', '');
+      document.body.appendChild(host);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(host, { key: 'r' });
+
+      expect(handler).not.toHaveBeenCalled();
+      cleanup();
+      host.remove();
+    });
+
+    it('should skip when target is nested inside a contenteditable host', () => {
+      const host = document.createElement('div');
+      host.setAttribute('contenteditable', '');
+      const child = document.createElement('span');
+      host.appendChild(child);
+      document.body.appendChild(host);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(child, { key: 'r' });
+
+      expect(handler).not.toHaveBeenCalled();
+      cleanup();
+      host.remove();
+    });
+
+    it('should NOT skip for contenteditable="false"', () => {
+      const el = document.createElement('div');
+      el.setAttribute('contenteditable', 'false');
+      document.body.appendChild(el);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(el, { key: 'r' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      cleanup();
+      el.remove();
+    });
+
+    it('should NOT skip for contenteditable="FALSE" (case-insensitive)', () => {
+      const el = document.createElement('div');
+      el.setAttribute('contenteditable', 'FALSE');
+      document.body.appendChild(el);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(el, { key: 'r' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      cleanup();
+      el.remove();
+    });
+
+    it('should skip when target is a non-HTML element inside contenteditable', () => {
+      const host = document.createElement('div');
+      host.setAttribute('contenteditable', '');
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      host.appendChild(svg);
+      document.body.appendChild(host);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(svg, { key: 'r' });
+
+      expect(handler).not.toHaveBeenCalled();
+      cleanup();
+      host.remove();
+    });
+
+    it('should still fire on non-editable targets when enabled', () => {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchOn(div, { key: 'r' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      cleanup();
+      div.remove();
+    });
+
+    it('should fire when the target is not an element (document)', () => {
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, {
+        ignoreEditableTargets: true,
+      });
+
+      dispatchKeydown({ key: 'r' }); // dispatched on document -> target is document
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      cleanup();
+    });
+  });
+
+  // ===========================================================================
+  // Conditional handlers (return false to decline)
+  // ===========================================================================
+
+  describe('conditional handlers', () => {
+    it('should not preventDefault when the handler returns false', () => {
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), () => false);
+
+      const event = dispatchKeydown({ key: 'r' });
+
+      expect(event.defaultPrevented).toBe(false);
+      cleanup();
+    });
+
+    it('should preventDefault when the handler returns undefined', () => {
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), () => undefined);
+
+      const event = dispatchKeydown({ key: 'r' });
+
+      expect(event.defaultPrevented).toBe(true);
+      cleanup();
+    });
+
+    it('should not stop propagation when the handler returns false', () => {
+      const parentHandler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), () => false, {
+        stopPropagation: true,
+        stopImmediatePropagation: true,
+      });
+      document.addEventListener('keydown', parentHandler);
+
+      dispatchKeydown({ key: 'r' });
+
+      expect(parentHandler).toHaveBeenCalled();
+      cleanup();
+      document.removeEventListener('keydown', parentHandler);
+    });
+
+    it('should keep a once handler registered when it declines', () => {
+      const handler = vi.fn().mockReturnValueOnce(false).mockReturnValueOnce(undefined);
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler, { once: true });
+
+      dispatchKeydown({ key: 'r' }); // declines -> stays registered
+      dispatchKeydown({ key: 'r' }); // handles -> auto-removes
+      dispatchKeydown({ key: 'r' }); // already removed
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      cleanup();
+    });
+
+    it('should receive the keyboard event', () => {
+      const handler = vi.fn();
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), handler);
+
+      const event = dispatchKeydown({ key: 'r' });
+
+      expect(handler).toHaveBeenCalledWith(event);
+      cleanup();
+    });
+
+    it('should consume the key for a value-returning (async) handler', () => {
+      // Only a literal false declines; a Promise (or any other value) consumes.
+      const cleanup = ShortcutManager.on(KeyboardShortcut.key('r'), async () => {
+        await Promise.resolve();
+      });
+
+      const event = dispatchKeydown({ key: 'r' });
+
+      expect(event.defaultPrevented).toBe(true);
+      cleanup();
+    });
+  });
+
+  // ===========================================================================
   // Convenience Methods
   // ===========================================================================
 
@@ -391,6 +627,21 @@ describe('ShortcutManager', () => {
 
       expect(group).toBeInstanceOf(ShortcutGroup);
     });
+
+    it('should pass default options to the group', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      const handler = vi.fn();
+      const group = ShortcutManager.createGroup({ ignoreEditableTargets: true });
+      group.add(KeyboardShortcut.key('r'), handler);
+
+      const event = new KeyboardEvent('keydown', { key: 'r', bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+
+      expect(handler).not.toHaveBeenCalled();
+      group.cleanup();
+      input.remove();
+    });
   });
 });
 
@@ -461,6 +712,36 @@ describe('ShortcutGroup', () => {
       group.cleanup();
     });
 
+    it('should apply group default options', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      const handler = vi.fn();
+      const group = new ShortcutGroup({ ignoreEditableTargets: true });
+      group.add(KeyboardShortcut.key('r'), handler);
+
+      const event = new KeyboardEvent('keydown', { key: 'r', bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+
+      expect(handler).not.toHaveBeenCalled();
+      group.cleanup();
+      input.remove();
+    });
+
+    it('should let per-add options override group defaults', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      const handler = vi.fn();
+      const group = new ShortcutGroup({ ignoreEditableTargets: true });
+      group.add(KeyboardShortcut.key('r'), handler, { ignoreEditableTargets: false });
+
+      const event = new KeyboardEvent('keydown', { key: 'r', bubbles: true, cancelable: true });
+      input.dispatchEvent(event);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      group.cleanup();
+      input.remove();
+    });
+
     it('should support chaining multiple adds', () => {
       const group = new ShortcutGroup();
       const handler1 = vi.fn();
@@ -510,6 +791,26 @@ describe('ShortcutGroup', () => {
       // Should only trigger once due to once: true in onEscape
       expect(handler).toHaveBeenCalledTimes(1);
       group.cleanup();
+    });
+
+    it('should be exempt from group ignoreEditableTargets default', () => {
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      const handler = vi.fn();
+      const group = new ShortcutGroup({ ignoreEditableTargets: true });
+      group.addEscape(handler);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(event);
+
+      // Escape still fires while focus is in an input (close-modal-while-typing).
+      expect(handler).toHaveBeenCalledTimes(1);
+      group.cleanup();
+      input.remove();
     });
   });
 


### PR DESCRIPTION
## Summary

Makes `ShortcutManager` usable as the surface for an app's global editing shortcuts, so a consumer can drop a hand-rolled `document` `keydown` listener. Closes the four gaps tracked in #164.

## Changes

- **`ignoreEditableTargets`** option (default `false`): skips a shortcut while focus is in an `<input>`/`<textarea>`/`<select>` or a `[contenteditable]` host (nested included; `contenteditable="false"` excluded, case-insensitive).
- **Conditional handlers**: `ShortcutHandler` receives the `KeyboardEvent` and may return `false` to decline the key. The handler now runs **before** `preventDefault`; declining skips `preventDefault`/`stopPropagation` and keeps a `once` handler registered.
- **Group defaults**: `createGroup(defaultOptions?)` applies options to every `add` (per-`add` overrides); `addEscape` stays exempt so Escape still fires while typing.
- **`cmdOrCtrl` / `cmdOrCtrlShift`**: one registration matching exactly one of Ctrl/Meta (XOR), for cross-platform undo/redo.

## Design decisions (per library principles)

- `ignoreEditableTargets` defaults to `false` — a `true` default would break `onEscape()` / `Ctrl+S`-in-input; app surfaces opt in once via the group.
- `cmdOrCtrl` is match-either-everywhere — no `keyboard → device` module-boundary import just for platform cosmetics.
- Handler return type is `unknown` (not `void | boolean`) to keep value-returning/`async` handlers source-compatible; only literal `false` declines.

## Acceptance criteria (#164)

- [x] Bare `R` does not fire / `preventDefault` while focus is in an editable element, via a built-in option
- [x] A handler can decline a key based on app state (event access + `false` return)
- [x] One registration expresses "Cmd-or-Ctrl+Z"
- [x] App surface enables editable-target skip once via the group
- [x] No regression for existing scoped/modifier consumers

## Quality

- [x] 4640 tests pass; keyboard module 100% coverage (stmts/branch/func/lines)
- [x] typecheck, lint, build clean
- [x] Docs updated (`documentation/keyboard.md`, README — replaced a stale example)

## Reviews

- **Adversarial cross-model review (agy / Gemini 3.1 Pro)**: 4 findings accepted and fixed (async-handler type narrowing → `unknown`; `instanceof Element` for SVG-in-contenteditable; case-insensitive `contenteditable`; `cmdOrCtrl` XOR). 2 rejected as deliberate design; 1 deferred.
- **Security review**: no vulnerabilities introduced.

## Follow-up

`ignoreEditableTargets` misses inputs inside an open Shadow DOM (`event.target` retargeting) — tracked in #166; needs real-browser test infrastructure, documented as a known limitation.