### PR TITLE
chore(ci): ignore TypeScript 7.0.x until tooling supports the native port

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      # typescript-eslint rejects the TS 7.0 native port outright, and there is no
+      # stable typescript-eslint release supporting TS 7 yet (tracking:
+      # typescript-eslint#10940). Block the 7.0.x line so only 7.1.0 — expected to
+      # restore tooling support — reopens a PR.
+      - dependency-name: "typescript"
+        versions: ["7.0.x"]
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
## Summary

Dependabot #179 bumps TypeScript to 7.0.x (the native Go port), which our lint gate cannot pass: `typescript-eslint` rejects TS 7.0 outright, and no stable `typescript-eslint` release supports TS 7 yet (tracking: [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940)).

This adds a scoped Dependabot `ignore` for the `typescript` `7.0.x` line so we stop getting a red PR on every 7.0 patch. `7.1.0` is deliberately **not** covered — it is expected to restore tooling support, so a fresh PR will reopen when it lands and act as our natural upgrade reminder.

## Verification

- [x] `ignore` scoped to `7.0.x` only — `7.1.0` and later still trigger a PR
- [x] Pre-push gate green (format, lint, typecheck, test, build, size)
- [ ] #179 closed via `@dependabot close` after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)