### PR TITLE
feat(request): support Retry-After header

### DIFF
--- a/.claude/PROJECT.md
+++ b/.claude/PROJECT.md
@@ -16,7 +16,7 @@ package info, structure, and tooling details.
 
 ```text
 src/
-├── core/               # Core utilities (types, errors, validation, result, logger, debounce, throttle)
+├── core/               # Core utilities (types, errors, validation, result, logger, debounce, throttle, backoff)
 │   ├── errors/         # Error classes (BrowserUtilsError, ValidationError, etc.)
 │   ├── result/         # Result<T,E> type for explicit error handling
 │   ├── validation/     # Input validation utilities (incl. CacheValidator)
@@ -136,45 +136,45 @@ Module boundaries are enforced via `eslint-plugin-boundaries`:
 
 ## Current Modules (37)
 
-| Module       | Path                | Purpose                                                            |
-| ------------ | ------------------- | ------------------------------------------------------------------ |
-| core         | `src/core/`         | Types, errors, validation, Result, LoggerLike, debounce, throttle  |
-| a11y         | `src/a11y/`         | Accessibility (AriaUtils, LiveAnnouncer, ReducedMotion, SkipLink)  |
-| broadcast    | `src/broadcast/`    | BroadcastChannel cross-tab messaging                               |
-| cache        | `src/cache/`        | HTTP cache with stale-while-revalidate                             |
-| clipboard    | `src/clipboard/`    | Clipboard API with fallback                                        |
-| color        | `src/color/`        | Color parse/convert/validate/contrast/manipulate                   |
-| cookie       | `src/cookie/`       | Cookie management (Secure, SameSite)                               |
-| csp          | `src/csp/`          | CSP-aware security utilities                                       |
-| device       | `src/device/`       | Device/browser detection                                           |
-| download     | `src/download/`     | File download with validation                                      |
-| encryption   | `src/encryption/`   | AES-GCM encrypted storage (PBKDF2)                                 |
-| events       | `src/events/`       | Event delegation (re-exports debounce/throttle from core)          |
-| features     | `src/features/`     | Browser feature detection                                          |
-| focus        | `src/focus/`        | Focus trap, focusable elements                                     |
-| form         | `src/form/`         | Serialization, validation                                          |
-| fullscreen   | `src/fullscreen/`   | Fullscreen API wrapper                                             |
-| geolocation  | `src/geolocation/`  | Geolocation API wrapper                                            |
-| html         | `src/html/`         | HTML escaping, DOM helpers                                         |
-| idle         | `src/idle/`         | requestIdleCallback utilities                                      |
-| indexeddb    | `src/indexeddb/`    | IndexedDB wrapper (large data)                                     |
-| intl         | `src/intl/`         | Intl formatting (number/date/plural/collator) + locale negotiation |
-| keyboard     | `src/keyboard/`     | Keyboard shortcut manager                                          |
-| logging      | `src/logging/`      | Console logging with levels                                        |
-| media        | `src/media/`        | Media queries, breakpoints                                         |
-| network      | `src/network/`      | Network status, retry queue                                        |
-| notification | `src/notification/` | Browser notifications                                              |
-| observe      | `src/observe/`      | Intersection/Resize/Mutation                                       |
-| offline      | `src/offline/`      | Offline queue for data sync                                        |
-| performance  | `src/performance/`  | Performance measurement utilities                                  |
-| request      | `src/request/`      | Fetch/XHR interceptor with middleware                              |
-| sanitize     | `src/sanitize/`     | HTML sanitization                                                  |
-| scroll       | `src/scroll/`       | Scroll utilities                                                   |
-| session      | `src/session/`      | SessionStorage management                                          |
-| storage      | `src/storage/`      | LocalStorage with memory fallback                                  |
-| url          | `src/url/`          | URL builder, query params                                          |
-| visibility   | `src/visibility/`   | Page Visibility API wrapper                                        |
-| websocket    | `src/websocket/`    | WebSocket with auto-reconnect                                      |
+| Module       | Path                | Purpose                                                                    |
+| ------------ | ------------------- | -------------------------------------------------------------------------- |
+| core         | `src/core/`         | Types, errors, validation, Result, LoggerLike, debounce, throttle, backoff |
+| a11y         | `src/a11y/`         | Accessibility (AriaUtils, LiveAnnouncer, ReducedMotion, SkipLink)          |
+| broadcast    | `src/broadcast/`    | BroadcastChannel cross-tab messaging                                       |
+| cache        | `src/cache/`        | HTTP cache with stale-while-revalidate                                     |
+| clipboard    | `src/clipboard/`    | Clipboard API with fallback                                                |
+| color        | `src/color/`        | Color parse/convert/validate/contrast/manipulate                           |
+| cookie       | `src/cookie/`       | Cookie management (Secure, SameSite)                                       |
+| csp          | `src/csp/`          | CSP-aware security utilities                                               |
+| device       | `src/device/`       | Device/browser detection                                                   |
+| download     | `src/download/`     | File download with validation                                              |
+| encryption   | `src/encryption/`   | AES-GCM encrypted storage (PBKDF2)                                         |
+| events       | `src/events/`       | Event delegation (re-exports debounce/throttle from core)                  |
+| features     | `src/features/`     | Browser feature detection                                                  |
+| focus        | `src/focus/`        | Focus trap, focusable elements                                             |
+| form         | `src/form/`         | Serialization, validation                                                  |
+| fullscreen   | `src/fullscreen/`   | Fullscreen API wrapper                                                     |
+| geolocation  | `src/geolocation/`  | Geolocation API wrapper                                                    |
+| html         | `src/html/`         | HTML escaping, DOM helpers                                                 |
+| idle         | `src/idle/`         | requestIdleCallback utilities                                              |
+| indexeddb    | `src/indexeddb/`    | IndexedDB wrapper (large data)                                             |
+| intl         | `src/intl/`         | Intl formatting (number/date/plural/collator) + locale negotiation         |
+| keyboard     | `src/keyboard/`     | Keyboard shortcut manager                                                  |
+| logging      | `src/logging/`      | Console logging with levels                                                |
+| media        | `src/media/`        | Media queries, breakpoints                                                 |
+| network      | `src/network/`      | Network status, retry queue                                                |
+| notification | `src/notification/` | Browser notifications                                                      |
+| observe      | `src/observe/`      | Intersection/Resize/Mutation                                               |
+| offline      | `src/offline/`      | Offline queue for data sync                                                |
+| performance  | `src/performance/`  | Performance measurement utilities                                          |
+| request      | `src/request/`      | Fetch/XHR interceptor with middleware                                      |
+| sanitize     | `src/sanitize/`     | HTML sanitization                                                          |
+| scroll       | `src/scroll/`       | Scroll utilities                                                           |
+| session      | `src/session/`      | SessionStorage management                                                  |
+| storage      | `src/storage/`      | LocalStorage with memory fallback                                          |
+| url          | `src/url/`          | URL builder, query params                                                  |
+| visibility   | `src/visibility/`   | Page Visibility API wrapper                                                |
+| websocket    | `src/websocket/`    | WebSocket with auto-reconnect                                              |
 
 ## Planned Modules
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,23 @@ import { RetryQueue } from '@zappzarapp/browser-utils/network';
 
 const queue = RetryQueue.create({
   maxRetries: 3,
-  backoffStrategy: 'exponential',
+  backoff: 'exponential',
   networkAware: true,
 });
 
-const result = await queue.add({
-  operation: () => fetch('/api/data').then((r) => r.json()),
+const result = await queue.add(() => fetch('/api/data').then((r) => r.json()));
+```
+
+### Automatic Request Retry
+
+```typescript
+import { RequestInterceptor } from '@zappzarapp/browser-utils/request';
+
+// Opt-in retry for idempotent requests with exponential backoff;
+// Retry-After response headers are honored (capped at maxDelay)
+const api = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+  retry: { maxRetries: 3 },
 });
 ```
 

--- a/documentation/core.md
+++ b/documentation/core.md
@@ -41,24 +41,26 @@ const id = generateUUID(); // "550e8400-e29b-41d4-a716-446655440000"
 
 ## Exports
 
-| Export              | Type     | Description                            |
-| ------------------- | -------- | -------------------------------------- |
-| `Result`            | Object   | Result type constructors and utilities |
-| `BrowserUtilsError` | Class    | Abstract base error class              |
-| `ValidationError`   | Class    | Validation failure error               |
-| `StorageError`      | Class    | Storage operation error                |
-| `ClipboardError`    | Class    | Clipboard operation error              |
-| `NetworkError`      | Class    | Network operation error                |
-| `FullscreenError`   | Class    | Fullscreen API error                   |
-| `NotificationError` | Class    | Notification API error                 |
-| `CookieError`       | Class    | Cookie operation error                 |
-| `UrlError`          | Class    | URL validation/parsing error           |
-| `GeolocationError`  | Class    | Geolocation API error                  |
-| `EncryptionError`   | Class    | Encryption operation error             |
-| `CryptoError`       | Class    | Crypto API error                       |
-| `Validator`         | Object   | Unified validation facade              |
-| `generateUUID`      | Function | Secure UUID v4 generation              |
-| `CleanupFn`         | Type     | Cleanup function type                  |
+| Export                | Type     | Description                                |
+| --------------------- | -------- | ------------------------------------------ |
+| `Result`              | Object   | Result type constructors and utilities     |
+| `BrowserUtilsError`   | Class    | Abstract base error class                  |
+| `ValidationError`     | Class    | Validation failure error                   |
+| `StorageError`        | Class    | Storage operation error                    |
+| `ClipboardError`      | Class    | Clipboard operation error                  |
+| `NetworkError`        | Class    | Network operation error                    |
+| `FullscreenError`     | Class    | Fullscreen API error                       |
+| `NotificationError`   | Class    | Notification API error                     |
+| `CookieError`         | Class    | Cookie operation error                     |
+| `UrlError`            | Class    | URL validation/parsing error               |
+| `GeolocationError`    | Class    | Geolocation API error                      |
+| `EncryptionError`     | Class    | Encryption operation error                 |
+| `CryptoError`         | Class    | Crypto API error                           |
+| `Validator`           | Object   | Unified validation facade                  |
+| `generateUUID`        | Function | Secure UUID v4 generation                  |
+| `computeBackoffDelay` | Function | Retry delay computation (backoff + jitter) |
+| `BackoffStrategy`     | Type     | Backoff strategy type                      |
+| `CleanupFn`           | Type     | Cleanup function type                      |
 
 ---
 

--- a/documentation/network.md
+++ b/documentation/network.md
@@ -112,6 +112,22 @@ const queue = RetryQueue.create({
 | `linear`      | Delay = baseDelay \* attempt       |
 | `exponential` | Delay = baseDelay \* 2^(attempt-1) |
 
+### Retry-After Hints
+
+When a failed operation throws an error carrying a finite, non-negative numeric
+`retryAfterMs` field, that delay replaces the computed backoff for the next
+attempt — without jitter, capped at `maxDelay`. The `RequestInterceptor`
+(request module) sets this field on `RESPONSE_ERROR` when the server sent a
+`Retry-After` header, so both compose out of the box:
+
+```typescript
+const api = RequestInterceptor.create({ baseUrl, throwOnError: true });
+const queue = RetryQueue.create({ maxRetries: 3 });
+
+// A 429 with "Retry-After: 30" delays the next attempt by 30 seconds
+await queue.add(() => api.post('/sync', payload));
+```
+
 ### Rate Limiting
 
 Prevents reconnect storms by limiting how many operations are processed within a

--- a/documentation/request.md
+++ b/documentation/request.md
@@ -33,6 +33,7 @@ api.destroy();
 | Request Middleware    | Transform requests before sending               |
 | Response Middleware   | Transform responses after receiving             |
 | Error Middleware      | Handle errors in middleware chain               |
+| Automatic Retry       | Opt-in retry with backoff and Retry-After       |
 | Request Timing        | Track request duration and performance          |
 | URL Validation        | Protocol allowlist and pattern blocking         |
 | Credential Protection | Prevent credential leakage to different origins |
@@ -57,6 +58,8 @@ api.destroy();
 | `HttpMethod`                 | HTTP method type                                  |
 | `RequestError`               | Request-specific error class                      |
 | `RequestErrorCode`           | Error code enum                                   |
+| `RequestRetryConfig`         | Retry configuration options                       |
+| `parseRetryAfter`            | Parse a Retry-After header value to milliseconds  |
 | `combineAbortSignals`        | Utility to merge two AbortSignals into one        |
 | `ProgressInfo`               | Progress data: loaded, total, percentage          |
 | `ProgressCallback`           | Progress event callback type                      |
@@ -79,6 +82,7 @@ api.destroy();
 | `validateCredentialOrigin` | `boolean`               | `true`       | Prevent credentials to different origins |
 | `blockPrivateIPs`          | `boolean`               | `false`      | Block requests to private/internal IPs   |
 | `expectedContentType`      | `string \| string[]`    | `undefined`  | Validate response Content-Type           |
+| `retry`                    | `RequestRetryConfig`    | `undefined`  | Automatic retry (see Automatic Retry)    |
 
 ## API Reference
 
@@ -353,18 +357,12 @@ api.use({
 });
 ```
 
-### Retry Middleware
+### Retry
 
-```typescript
-api.use({
-  onError: async (error, config) => {
-    if (error.code === 'TIMEOUT' && config.metadata?.retryCount === undefined) {
-      // Retry logic would need custom implementation
-      console.log('Request timed out, consider retry');
-    }
-  },
-});
-```
+Retries are built in — configure the `retry` option instead of writing
+middleware (see [Automatic Retry](#automatic-retry)). Middleware hooks only
+observe the final outcome: `onResponse` and `onError` run once per call, after
+all retry attempts.
 
 ### Request ID Middleware
 
@@ -415,6 +413,79 @@ const api2 = RequestInterceptor.create({
 const response = await api.fetch('/report.csv', {
   expectedContentType: 'text/csv',
 });
+```
+
+## Automatic Retry
+
+Opt-in retry for transient failures. Network errors, timeouts, and responses
+with a retryable status code are retried with backoff. A `Retry-After` response
+header (delta-seconds or HTTP-date) overrides the computed backoff delay —
+without jitter, capped at `maxDelay`.
+
+```typescript
+const api = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+  retry: { maxRetries: 3 },
+});
+
+// 429/503 responses with Retry-After are retried when the server allows it
+const response = await api.get('/rate-limited');
+```
+
+### Retry Options
+
+| Option        | Type              | Default                                   | Description                       |
+| ------------- | ----------------- | ----------------------------------------- | --------------------------------- |
+| `maxRetries`  | `number`          | `3`                                       | Retries after the initial request |
+| `backoff`     | `BackoffStrategy` | `'exponential'`                           | Backoff strategy                  |
+| `baseDelay`   | `number`          | `1000`                                    | Base delay in milliseconds        |
+| `maxDelay`    | `number`          | `30000`                                   | Delay cap (also for Retry-After)  |
+| `jitter`      | `boolean`         | `true`                                    | Jitter on computed backoff only   |
+| `methods`     | `HttpMethod[]`    | `['GET','HEAD','OPTIONS','PUT','DELETE']` | Methods eligible for retry        |
+| `statusCodes` | `number[]`        | `[408, 429, 500, 502, 503, 504]`          | Status codes that trigger retry   |
+
+### Retry Rules
+
+- Only idempotent methods are retried by default. Retrying `POST` can duplicate
+  side effects — opt in explicitly via `methods` if your endpoint is safe to
+  replay.
+- Requests with a `ReadableStream` body are never retried (the stream is
+  consumed by the first attempt).
+- Aborted requests are never retried; aborting during a retry wait rejects with
+  `ABORTED`.
+- Middleware sees only the final outcome: `onRequest` runs once before the first
+  attempt, `onResponse`/`onError` and timing hooks fire once per call.
+
+### RetryQueue Integration
+
+With `throwOnError`, a thrown `RESPONSE_ERROR` carries the parsed header as
+`retryAfterMs`. The `RetryQueue` (network module) picks this hint up and uses it
+instead of its computed backoff — useful for background sync without enabling
+interceptor-level retries:
+
+```typescript
+import { RetryQueue } from '@zappzarapp/browser-utils/network';
+
+const api = RequestInterceptor.create({
+  baseUrl: 'https://api.example.com',
+  throwOnError: true,
+});
+const queue = RetryQueue.create({ maxRetries: 3 });
+
+// A 429 with Retry-After delays the queue's next attempt accordingly
+await queue.add(() => api.post('/sync', payload));
+```
+
+### parseRetryAfter()
+
+Parse a `Retry-After` header value yourself:
+
+```typescript
+import { parseRetryAfter } from '@zappzarapp/browser-utils/request';
+
+parseRetryAfter('120'); // 120000 (delta-seconds)
+parseRetryAfter('Fri, 31 Dec 2027 23:59:59 GMT'); // ms until that date
+parseRetryAfter('garbage'); // null
 ```
 
 ## Combining Abort Signals

--- a/src/core/Backoff.ts
+++ b/src/core/Backoff.ts
@@ -1,0 +1,77 @@
+/**
+ * Backoff - Retry delay computation shared across modules.
+ *
+ * Features:
+ * - Constant, linear, and exponential strategies
+ * - Maximum delay cap (hard upper bound, also with jitter)
+ * - Optional equal jitter using cryptographic randomness (prevents thundering herd)
+ *
+ * @example
+ * ```TypeScript
+ * // Exponential backoff: 1000ms, 2000ms, 4000ms, ... capped at 30000ms
+ * const delay = computeBackoffDelay('exponential', attempt, 1000, 30000, true);
+ * await new Promise((resolve) => setTimeout(resolve, delay));
+ * ```
+ */
+
+/**
+ * Backoff strategy for retry delays.
+ */
+export type BackoffStrategy = 'linear' | 'exponential' | 'constant';
+
+/**
+ * Generate a cryptographically secure random number between 0 and 1.
+ * Uses crypto.getRandomValues() for security consistency.
+ */
+function cryptoRandom(): number {
+  const buffer = new Uint32Array(1);
+  crypto.getRandomValues(buffer);
+  return buffer[0]! / 0xffffffff;
+}
+
+/**
+ * Compute the retry delay for a given attempt.
+ *
+ * @param strategy Backoff strategy
+ * @param attempt Retry attempt number (1-based)
+ * @param baseDelay Base delay in milliseconds
+ * @param maxDelay Maximum delay cap in milliseconds (never exceeded)
+ * @param jitter Apply equal jitter: multiply the capped delay by a random
+ *               factor between 0.5 and 1.0, so delays spread out without
+ *               exceeding `maxDelay`
+ * @returns Delay in milliseconds (floored to an integer)
+ */
+export function computeBackoffDelay(
+  strategy: BackoffStrategy,
+  attempt: number,
+  baseDelay: number,
+  maxDelay: number,
+  jitter: boolean
+): number {
+  let delay: number;
+
+  switch (strategy) {
+    case 'constant':
+      delay = baseDelay;
+      break;
+    case 'linear':
+      delay = baseDelay * attempt;
+      break;
+    case 'exponential':
+    default:
+      delay = baseDelay * Math.pow(2, attempt - 1);
+      break;
+  }
+
+  // Apply max delay cap
+  delay = Math.min(delay, maxDelay);
+
+  // Apply equal jitter (factor 0.5-1.0) using cryptographic randomness.
+  // Jittering downward from the capped delay keeps the spread intact at the
+  // cap while never exceeding maxDelay.
+  if (jitter) {
+    delay = delay * (0.5 + cryptoRandom() * 0.5);
+  }
+
+  return Math.floor(delay);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -55,6 +55,10 @@ export { noopLogger } from './logger.js';
 export { generateUUID, CryptoError } from './crypto.js';
 export type { CryptoErrorCode } from './crypto.js';
 
+// Backoff
+export { computeBackoffDelay } from './Backoff.js';
+export type { BackoffStrategy } from './Backoff.js';
+
 // Debounce & Throttle
 export { debounce } from './Debounce.js';
 export type { DebounceOptions, DebouncedFunction } from './Debounce.js';

--- a/src/network/RetryQueue.ts
+++ b/src/network/RetryQueue.ts
@@ -3,6 +3,7 @@
  *
  * Features:
  * - Exponential backoff
+ * - Honors `Retry-After` hints (`retryAfterMs` field on thrown errors)
  * - Network-aware (pauses when offline)
  * - Configurable retry limits
  * - Optional rate limiting (prevents reconnect storms)
@@ -32,6 +33,16 @@
  * console.log(queue.getStats());
  * ```
  *
+ * @example Honoring Retry-After
+ * ```TypeScript
+ * // When a failed operation throws an error carrying a numeric `retryAfterMs`
+ * // field (e.g. a RequestError from an interceptor with throwOnError that saw
+ * // a 429/503 Retry-After header), that delay replaces the computed backoff
+ * // for the next attempt. It is capped at `maxDelay` and applied without jitter.
+ * const queue = RetryQueue.create({ maxRetries: 3, maxDelay: 60000 });
+ * await queue.add(() => api.get('/rate-limited'));
+ * ```
+ *
  * @example With rate limiting
  * ```TypeScript
  * // Limit to 10 requests per 5 seconds to prevent reconnect storms
@@ -50,10 +61,15 @@
  * }
  * ```
  */
-import { NetworkError, type CleanupFn } from '../core/index.js';
+import {
+  NetworkError,
+  computeBackoffDelay,
+  type BackoffStrategy,
+  type CleanupFn,
+} from '../core/index.js';
 import { NetworkStatus } from './NetworkStatus.js';
 
-export type BackoffStrategy = 'linear' | 'exponential' | 'constant';
+export type { BackoffStrategy } from '../core/index.js';
 
 export type CircuitState = 'closed' | 'open' | 'half-open';
 
@@ -88,6 +104,7 @@ export interface RetryQueueOptions {
 
   /**
    * Maximum delay in milliseconds.
+   * Also caps `retryAfterMs` hints carried by thrown errors.
    * @default 30000
    */
   readonly maxDelay?: number;
@@ -449,7 +466,11 @@ export class RetryQueue {
         this.stats.retries++;
         this.emitRetry(item.attempts, error);
 
-        const delay = this.calculateDelay(item.attempts);
+        const retryAfterMs = this.extractRetryAfterMs(error);
+        const delay =
+          retryAfterMs !== null
+            ? Math.min(retryAfterMs, this.options.maxDelay)
+            : this.calculateDelay(item.attempts);
         await this.delay(delay);
       } else {
         // Max retries exceeded
@@ -514,30 +535,28 @@ export class RetryQueue {
   }
 
   private calculateDelay(attempt: number): number {
-    let delay: number;
+    return computeBackoffDelay(
+      this.options.backoff,
+      attempt,
+      this.options.baseDelay,
+      this.options.maxDelay,
+      this.options.jitter
+    );
+  }
 
-    switch (this.options.backoff) {
-      case 'constant':
-        delay = this.options.baseDelay;
-        break;
-      case 'linear':
-        delay = this.options.baseDelay * attempt;
-        break;
-      case 'exponential':
-      default:
-        delay = this.options.baseDelay * Math.pow(2, attempt - 1);
-        break;
+  /**
+   * Extract a `Retry-After` hint from a thrown error.
+   * Any error carrying a finite, non-negative numeric `retryAfterMs` field
+   * (e.g. RequestError from the request module) provides the hint.
+   */
+  private extractRetryAfterMs(error: unknown): number | null {
+    if (typeof error === 'object' && error !== null && 'retryAfterMs' in error) {
+      const value: unknown = error.retryAfterMs;
+      if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+        return value;
+      }
     }
-
-    // Apply max delay cap
-    delay = Math.min(delay, this.options.maxDelay);
-
-    // Apply jitter using cryptographic randomness for security consistency
-    if (this.options.jitter) {
-      delay = delay * (0.5 + this.cryptoRandom());
-    }
-
-    return Math.floor(delay);
+    return null;
   }
 
   private delay(ms: number): Promise<void> {
@@ -560,16 +579,6 @@ export class RetryQueue {
         void this.processQueue();
       }
     });
-  }
-
-  /**
-   * Generate a cryptographically secure random number between 0 and 1.
-   * Uses crypto.getRandomValues() for security consistency.
-   */
-  private cryptoRandom(): number {
-    const buffer = new Uint32Array(1);
-    crypto.getRandomValues(buffer);
-    return buffer[0]! / 0xffffffff;
   }
 
   /**

--- a/src/request/RequestInterceptor.ts
+++ b/src/request/RequestInterceptor.ts
@@ -5,6 +5,7 @@
  * - Fetch and XMLHttpRequest interception
  * - Request/response middleware chain
  * - Authentication header injection (Bearer tokens, API keys)
+ * - Automatic retry with backoff and Retry-After support (opt-in)
  * - Request logging and timing hooks
  * - Error handling middleware
  * - URL validation and security
@@ -53,6 +54,17 @@ import {
   emitTiming,
 } from './RequestMiddleware.js';
 import {
+  resolveRetryConfig,
+  eligibleRetryConfig,
+  retryDelayForResponse,
+  retryDelayForError,
+  waitRetryDelay,
+  discardResponseBody,
+  type RequestRetryConfig,
+  type ResolvedRetryConfig,
+} from './RequestRetry.js';
+import { parseRetryAfter } from './RetryAfter.js';
+import {
   validateUrl,
   validateCredentialOrigin,
   combineAbortSignals,
@@ -86,7 +98,13 @@ export class RequestError extends BrowserUtilsError {
   constructor(
     readonly code: RequestErrorCode,
     message: string,
-    cause?: unknown
+    cause?: unknown,
+    /**
+     * Parsed `Retry-After` hint in milliseconds.
+     * Present on RESPONSE_ERROR when the server sent the header.
+     * Consumers like RetryQueue use it to override their backoff delay.
+     */
+    readonly retryAfterMs?: number
   ) {
     super(message, cause);
   }
@@ -112,8 +130,13 @@ export class RequestError extends BrowserUtilsError {
     return new RequestError('REQUEST_FAILED', `Request to "${url}" failed`, cause);
   }
 
-  static responseError(status: number, statusText: string): RequestError {
-    return new RequestError('RESPONSE_ERROR', `Response error: ${status} ${statusText}`);
+  static responseError(status: number, statusText: string, retryAfterMs?: number): RequestError {
+    return new RequestError(
+      'RESPONSE_ERROR',
+      `Response error: ${status} ${statusText}`,
+      undefined,
+      retryAfterMs
+    );
   }
 
   static middlewareError(phase: string, cause?: unknown): RequestError {
@@ -332,6 +355,20 @@ export interface RequestInterceptorConfig {
    * Default: undefined (no validation).
    */
   readonly expectedContentType?: string | readonly string[];
+  /**
+   * Automatic retry for transient failures (opt-in).
+   *
+   * When set, network errors and responses with a retryable status code
+   * (default: 408, 429, 500, 502, 503, 504) are retried with backoff for
+   * retryable methods (default: idempotent methods only). A `Retry-After`
+   * response header overrides the computed backoff delay, capped at
+   * `retry.maxDelay`.
+   *
+   * Requests with a ReadableStream body are never retried (single-use).
+   *
+   * Default: undefined (no retries).
+   */
+  readonly retry?: RequestRetryConfig;
 }
 
 /**
@@ -398,12 +435,16 @@ export interface RequestInterceptorInstance {
 // =============================================================================
 
 const DEFAULT_CONFIG: Required<
-  Omit<RequestInterceptorConfig, 'auth' | 'baseUrl' | 'blockedPatterns' | 'expectedContentType'>
+  Omit<
+    RequestInterceptorConfig,
+    'auth' | 'baseUrl' | 'blockedPatterns' | 'expectedContentType' | 'retry'
+  >
 > & {
   auth: AuthConfig | null;
   baseUrl: string;
   blockedPatterns: readonly RegExp[];
   expectedContentType: string | readonly string[] | undefined;
+  retry: RequestRetryConfig | undefined;
 } = {
   baseUrl: '',
   timeout: 30000,
@@ -415,6 +456,7 @@ const DEFAULT_CONFIG: Required<
   validateCredentialOrigin: true,
   blockPrivateIPs: false,
   expectedContentType: undefined,
+  retry: undefined,
 } as const;
 
 /**
@@ -513,6 +555,22 @@ export const RequestInterceptor = {
    *   console.log(`${timing.method} ${timing.url}: ${timing.duration}ms`);
    * });
    * ```
+   *
+   * @example With automatic retry
+   * ```TypeScript
+   * // Retries idempotent requests on 408/429/500/502/503/504 and network
+   * // errors with exponential backoff, honoring Retry-After headers
+   * const api = RequestInterceptor.create({
+   *   baseUrl: 'https://api.example.com',
+   *   retry: { maxRetries: 3 },
+   * });
+   *
+   * // Opt POST in explicitly (may duplicate side effects)
+   * const submitApi = RequestInterceptor.create({
+   *   baseUrl: 'https://api.example.com',
+   *   retry: { maxRetries: 2, methods: ['GET', 'POST'] },
+   * });
+   * ```
    */
   create(config: RequestInterceptorConfig = {}): RequestInterceptorInstance {
     if (!RequestInterceptor.isSupported()) {
@@ -538,6 +596,10 @@ export const RequestInterceptor = {
         options.blockPrivateIPs
       );
     }
+
+    // Resolve and validate retry configuration once (opt-in)
+    const retryConfig: ResolvedRetryConfig | null =
+      options.retry !== undefined ? resolveRetryConfig(options.retry) : null;
 
     // State
     let currentAuth: AuthConfig | null = options.auth ?? null;
@@ -670,33 +732,78 @@ export const RequestInterceptor = {
       // Capture instance abort signal before any async work
       const instanceSignal = instanceAbortController.signal;
 
-      // Build and run request middleware
+      // Build and run request middleware (once - retries reuse the final config)
       let config = await buildRequestConfig(url, init);
       config = await runRequestMiddleware(config, middlewares);
-
-      // Setup abort controller and timeout
-      const abortController = new AbortController();
-      const timeoutId = createTimeout(config.timeout, abortController);
-
-      // Combine signals: per-request + instance-level + user-provided
-      let signal: AbortSignal = combineAbortSignals(instanceSignal, abortController.signal);
-      if (config.signal) {
-        signal = combineAbortSignals(config.signal, signal);
-      }
 
       const startTime = performance.now();
       const frozenConfig = freezeConfig(config);
 
-      try {
-        const response = await fetch(config.url, {
-          method: config.method,
-          headers: config.headers,
-          body: config.body,
-          signal,
-        });
+      // Finalize a failed request: emit timing, run error middleware, throw
+      const fail = async (error: RequestError): Promise<never> => {
+        const endTime = performance.now();
 
-        if (timeoutId !== null) clearTimeout(timeoutId);
+        emitTiming(
+          {
+            url: config.url,
+            method: config.method,
+            startTime,
+            endTime,
+            duration: endTime - startTime,
+            error: error.message,
+          },
+          timingHandlers
+        );
 
+        await runErrorMiddleware(error, frozenConfig, middlewares);
+        throw error;
+      };
+
+      // Wait out a retry delay; a user or instance abort ends the request
+      const waitBeforeRetry = async (ms: number): Promise<void> => {
+        try {
+          await waitRetryDelay(ms, [config.signal, instanceSignal]);
+        } catch {
+          await fail(RequestError.aborted(config.url));
+        }
+      };
+
+      // Combine long-lived signals (instance-level + user-provided) once per
+      // request, so retry attempts do not accumulate listeners on them
+      const baseSignal: AbortSignal = config.signal
+        ? combineAbortSignals(config.signal, instanceSignal)
+        : instanceSignal;
+
+      // Single fetch attempt with per-attempt timeout; failures are
+      // converted to RequestError
+      const performAttempt = async (): Promise<Response> => {
+        const abortController = new AbortController();
+        const timeoutId = createTimeout(config.timeout, abortController);
+
+        const signal = combineAbortSignals(baseSignal, abortController.signal);
+
+        try {
+          const response = await fetch(config.url, {
+            method: config.method,
+            headers: config.headers,
+            body: config.body,
+            signal,
+          });
+
+          if (timeoutId !== null) clearTimeout(timeoutId);
+
+          return response;
+        } catch (e) {
+          if (timeoutId !== null) clearTimeout(timeoutId);
+
+          const wasUserAborted = config.signal?.aborted === true || instanceSignal.aborted;
+          throw toRequestError(e, config.url, config.timeout ?? options.timeout, wasUserAborted);
+        }
+      };
+
+      // Finalize the accepted response: response middleware, Content-Type
+      // validation, timing, and throwOnError handling
+      const finalize = async (response: Response): Promise<Response> => {
         const endTime = performance.now();
         const duration = endTime - startTime;
 
@@ -729,40 +836,55 @@ export const RequestInterceptor = {
         );
 
         if (options.throwOnError && !response.ok) {
-          const error = RequestError.responseError(response.status, response.statusText);
+          const error = RequestError.responseError(
+            response.status,
+            response.statusText,
+            parseRetryAfter(interceptedResponse.headers.get('Retry-After')) ?? undefined
+          );
           await runErrorMiddleware(error, frozenConfig, middlewares);
           // noinspection ExceptionCaughtLocallyJS
           throw error;
         }
 
         return interceptedResponse.response;
-      } catch (e) {
-        if (timeoutId !== null) clearTimeout(timeoutId);
+      };
 
-        const endTime = performance.now();
-        const duration = endTime - startTime;
-        const wasUserAborted = config.signal?.aborted === true || instanceSignal.aborted;
-        const error = toRequestError(
-          e,
-          config.url,
-          config.timeout ?? options.timeout,
-          wasUserAborted
-        );
+      // Retry eligibility is fixed per request: opt-in config, retryable
+      // method, and a body that can be replayed (streams are single-use)
+      const retry = eligibleRetryConfig(retryConfig, config.method, config.body);
+      let attempt = 0;
+      let retryDelayMs: number | null = null;
 
-        emitTiming(
-          {
-            url: config.url,
-            method: config.method,
-            startTime,
-            endTime,
-            duration,
-            error: error.message,
-          },
-          timingHandlers
-        );
+      for (;;) {
+        if (retryDelayMs !== null) {
+          await waitBeforeRetry(retryDelayMs);
+          retryDelayMs = null;
+        }
 
-        await runErrorMiddleware(error, frozenConfig, middlewares);
-        throw error;
+        try {
+          const response = await performAttempt();
+
+          const delay = retryDelayForResponse(retry, attempt, response);
+          if (delay !== null) {
+            attempt++;
+            retryDelayMs = delay;
+            await discardResponseBody(response);
+            continue;
+          }
+
+          return await finalize(response);
+        } catch (e) {
+          const error = toRequestError(e, config.url, config.timeout ?? options.timeout, false);
+
+          const delay = retryDelayForError(retry, attempt, error);
+          if (delay !== null) {
+            attempt++;
+            retryDelayMs = delay;
+            continue;
+          }
+
+          return fail(error);
+        }
       }
     };
 
@@ -836,6 +958,7 @@ export const RequestInterceptor = {
           validateCredentialOrigin: options.validateCredentialOrigin,
           blockPrivateIPs: options.blockPrivateIPs,
           expectedContentType: options.expectedContentType,
+          retry: options.retry ? Object.freeze({ ...options.retry }) : undefined,
         });
       },
 

--- a/src/request/RequestRetry.ts
+++ b/src/request/RequestRetry.ts
@@ -1,0 +1,266 @@
+/**
+ * Request retry logic with Retry-After support.
+ * Internal module for the RequestInterceptor retry feature.
+ */
+
+import { computeBackoffDelay, type BackoffStrategy } from '../core/index.js';
+import { RequestError } from './RequestInterceptor.js';
+import type { HttpMethod, RequestErrorCode } from './RequestInterceptor.js';
+import { parseRetryAfter } from './RetryAfter.js';
+
+/**
+ * Retry configuration for the request interceptor.
+ * Retries are opt-in; without this config no request is ever retried.
+ */
+export interface RequestRetryConfig {
+  /**
+   * Maximum retry attempts (in addition to the initial request).
+   * @default 3
+   */
+  readonly maxRetries?: number;
+
+  /**
+   * Backoff strategy.
+   * @default 'exponential'
+   */
+  readonly backoff?: BackoffStrategy;
+
+  /**
+   * Base delay in milliseconds.
+   * @default 1000
+   */
+  readonly baseDelay?: number;
+
+  /**
+   * Maximum delay in milliseconds.
+   * Also caps delays requested via the `Retry-After` response header.
+   * @default 30000
+   */
+  readonly maxDelay?: number;
+
+  /**
+   * Add jitter to computed backoff delays (prevents thundering herd).
+   * Server-provided `Retry-After` delays are never jittered.
+   * @default true
+   */
+  readonly jitter?: boolean;
+
+  /**
+   * HTTP methods eligible for retry.
+   * Defaults to idempotent methods only; retrying POST can duplicate
+   * side effects and requires explicit opt-in.
+   * @default ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']
+   */
+  readonly methods?: readonly HttpMethod[];
+
+  /**
+   * Response status codes that trigger a retry.
+   * @default [408, 429, 500, 502, 503, 504]
+   */
+  readonly statusCodes?: readonly number[];
+}
+
+/**
+ * Retry configuration with all defaults applied.
+ */
+export interface ResolvedRetryConfig {
+  readonly maxRetries: number;
+  readonly backoff: BackoffStrategy;
+  readonly baseDelay: number;
+  readonly maxDelay: number;
+  readonly jitter: boolean;
+  readonly methods: readonly HttpMethod[];
+  readonly statusCodes: readonly number[];
+}
+
+const DEFAULT_RETRY_METHODS: readonly HttpMethod[] = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+
+const DEFAULT_RETRY_STATUS_CODES: readonly number[] = [408, 429, 500, 502, 503, 504];
+
+/**
+ * Error codes considered transient and therefore retryable.
+ * Aborts and configuration/validation errors are never retried.
+ */
+const RETRYABLE_ERROR_CODES: ReadonlySet<RequestErrorCode> = new Set(['REQUEST_FAILED', 'TIMEOUT']);
+
+/**
+ * Apply defaults and validate retry configuration.
+ * @throws {RequestError} INVALID_CONFIG for non-positive delays or invalid limits
+ */
+export function resolveRetryConfig(config: RequestRetryConfig): ResolvedRetryConfig {
+  const resolved: ResolvedRetryConfig = {
+    maxRetries: config.maxRetries ?? 3,
+    backoff: config.backoff ?? 'exponential',
+    baseDelay: config.baseDelay ?? 1000,
+    maxDelay: config.maxDelay ?? 30000,
+    jitter: config.jitter ?? true,
+    methods: config.methods ?? DEFAULT_RETRY_METHODS,
+    statusCodes: config.statusCodes ?? DEFAULT_RETRY_STATUS_CODES,
+  };
+
+  if (!Number.isInteger(resolved.maxRetries) || resolved.maxRetries < 0) {
+    throw RequestError.invalidConfig('retry.maxRetries must be a non-negative integer');
+  }
+  if (resolved.baseDelay <= 0) {
+    throw RequestError.invalidConfig('retry.baseDelay must be positive');
+  }
+  if (resolved.maxDelay <= 0) {
+    throw RequestError.invalidConfig('retry.maxDelay must be positive');
+  }
+  if (resolved.methods.length === 0) {
+    throw RequestError.invalidConfig('retry.methods must not be empty');
+  }
+  if (resolved.statusCodes.length === 0) {
+    throw RequestError.invalidConfig('retry.statusCodes must not be empty');
+  }
+
+  return resolved;
+}
+
+/**
+ * Check whether a request body can be replayed for a retry.
+ * A ReadableStream body is consumed by the first attempt and cannot be reused.
+ */
+export function isReplayableBody(body: BodyInit | null | undefined): boolean {
+  return !(typeof ReadableStream !== 'undefined' && body instanceof ReadableStream);
+}
+
+/**
+ * Check whether a failed request (no response) should be retried.
+ */
+export function isRetryableError(error: RequestError): boolean {
+  return RETRYABLE_ERROR_CODES.has(error.code);
+}
+
+/**
+ * Compute the delay before the next retry attempt.
+ * A valid `Retry-After` header replaces the computed backoff (without jitter)
+ * and is capped at `maxDelay`.
+ */
+export function computeRetryDelay(
+  config: ResolvedRetryConfig,
+  attempt: number,
+  retryAfterHeader: string | null
+): number {
+  const retryAfterMs = parseRetryAfter(retryAfterHeader);
+  if (retryAfterMs !== null) {
+    return Math.min(retryAfterMs, config.maxDelay);
+  }
+  return computeBackoffDelay(
+    config.backoff,
+    attempt,
+    config.baseDelay,
+    config.maxDelay,
+    config.jitter
+  );
+}
+
+/**
+ * Determine the effective retry config for a single request.
+ * Returns null when retries are disabled, the method is not eligible,
+ * or the body cannot be replayed.
+ */
+export function eligibleRetryConfig(
+  config: ResolvedRetryConfig | null,
+  method: HttpMethod,
+  body: BodyInit | null | undefined
+): ResolvedRetryConfig | null {
+  if (config === null || !config.methods.includes(method) || !isReplayableBody(body)) {
+    return null;
+  }
+  return config;
+}
+
+/**
+ * Delay before retrying a received response, or null when the response
+ * should not be retried (non-retryable status or retries exhausted).
+ * @param retry Effective retry config (null disables retries)
+ * @param attempt Number of retries already performed
+ * @param response Received response
+ */
+export function retryDelayForResponse(
+  retry: ResolvedRetryConfig | null,
+  attempt: number,
+  response: Response
+): number | null {
+  if (
+    retry === null ||
+    attempt >= retry.maxRetries ||
+    !retry.statusCodes.includes(response.status)
+  ) {
+    return null;
+  }
+  return computeRetryDelay(retry, attempt + 1, response.headers.get('Retry-After'));
+}
+
+/**
+ * Delay before retrying a failed request, or null when the error
+ * should not be retried (non-transient error or retries exhausted).
+ * @param retry Effective retry config (null disables retries)
+ * @param attempt Number of retries already performed
+ * @param error Converted request error
+ */
+export function retryDelayForError(
+  retry: ResolvedRetryConfig | null,
+  attempt: number,
+  error: RequestError
+): number | null {
+  if (retry === null || attempt >= retry.maxRetries || !isRetryableError(error)) {
+    return null;
+  }
+  return computeRetryDelay(retry, attempt + 1, null);
+}
+
+/**
+ * Wait before the next retry attempt.
+ * Rejects with an AbortError DOMException as soon as one of the given
+ * signals aborts, so callers can map it like an aborted fetch.
+ */
+export function waitRetryDelay(
+  ms: number,
+  signals: readonly (AbortSignal | undefined)[]
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const active = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+
+    const abort = (): void => {
+      reject(new DOMException('Retry delay was aborted', 'AbortError'));
+    };
+
+    if (active.some((signal) => signal.aborted)) {
+      abort();
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      for (const signal of active) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      resolve();
+    }, ms);
+
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      for (const signal of active) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      abort();
+    };
+
+    for (const signal of active) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Release an intermediate response before retrying, so the connection
+ * is not held open by an unconsumed body.
+ */
+export async function discardResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Ignore - the response is discarded either way
+  }
+}

--- a/src/request/RetryAfter.ts
+++ b/src/request/RetryAfter.ts
@@ -1,0 +1,52 @@
+/**
+ * Retry-After header parsing (RFC 9110, Section 10.2.3).
+ *
+ * Supports both header formats:
+ * - delta-seconds: `Retry-After: 120`
+ * - HTTP-date: `Retry-After: Fri, 31 Dec 1999 23:59:59 GMT`
+ *
+ * @example
+ * ```TypeScript
+ * const retryAfterMs = parseRetryAfter(response.headers.get('Retry-After'));
+ * if (retryAfterMs !== null) {
+ *   await new Promise((resolve) => setTimeout(resolve, retryAfterMs));
+ * }
+ * ```
+ */
+
+/**
+ * Parse a `Retry-After` header value into a delay in milliseconds.
+ *
+ * @param value Raw header value (or null when the header is absent)
+ * @returns Delay in milliseconds (>= 0), or null when the value is absent or invalid.
+ *          An HTTP-date in the past yields 0 (retry immediately).
+ */
+export function parseRetryAfter(value: string | null): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+
+  // delta-seconds: non-negative integer
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  // HTTP-date - every valid format contains letters (month name, "GMT").
+  // Reject letter-free garbage like "1.5" or "-5" that Date.parse would
+  // otherwise leniently interpret as a date.
+  if (!/[a-z]/i.test(trimmed)) {
+    return null;
+  }
+
+  const timestamp = Date.parse(trimmed);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+
+  return Math.max(0, timestamp - Date.now());
+}

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -14,6 +14,8 @@ export type {
   RequestInterceptorInstance,
 } from './RequestInterceptor.js';
 export { combineAbortSignals, validateContentType } from './RequestValidation.js';
+export { parseRetryAfter } from './RetryAfter.js';
+export type { RequestRetryConfig } from './RequestRetry.js';
 export {
   trackDownloadProgress,
   trackUploadProgress,

--- a/tests/core/Backoff.test.ts
+++ b/tests/core/Backoff.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Backoff Tests.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { computeBackoffDelay } from '../../src/core/index.js';
+
+describe('computeBackoffDelay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('strategies', () => {
+    it('should return constant delays', () => {
+      expect(computeBackoffDelay('constant', 1, 1000, 30000, false)).toBe(1000);
+      expect(computeBackoffDelay('constant', 2, 1000, 30000, false)).toBe(1000);
+      expect(computeBackoffDelay('constant', 5, 1000, 30000, false)).toBe(1000);
+    });
+
+    it('should return linearly increasing delays', () => {
+      expect(computeBackoffDelay('linear', 1, 1000, 30000, false)).toBe(1000);
+      expect(computeBackoffDelay('linear', 2, 1000, 30000, false)).toBe(2000);
+      expect(computeBackoffDelay('linear', 3, 1000, 30000, false)).toBe(3000);
+    });
+
+    it('should return exponentially increasing delays', () => {
+      expect(computeBackoffDelay('exponential', 1, 1000, 30000, false)).toBe(1000);
+      expect(computeBackoffDelay('exponential', 2, 1000, 30000, false)).toBe(2000);
+      expect(computeBackoffDelay('exponential', 3, 1000, 30000, false)).toBe(4000);
+      expect(computeBackoffDelay('exponential', 4, 1000, 30000, false)).toBe(8000);
+    });
+  });
+
+  describe('max delay cap', () => {
+    it('should cap exponential delays at maxDelay', () => {
+      expect(computeBackoffDelay('exponential', 10, 1000, 30000, false)).toBe(30000);
+    });
+
+    it('should cap linear delays at maxDelay', () => {
+      expect(computeBackoffDelay('linear', 100, 1000, 5000, false)).toBe(5000);
+    });
+  });
+
+  describe('jitter', () => {
+    it('should multiply the delay by 0.5 when random value is 0', () => {
+      vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+        if (array instanceof Uint32Array) {
+          array[0] = 0;
+        }
+        return array;
+      });
+
+      expect(computeBackoffDelay('constant', 1, 1000, 30000, true)).toBe(500);
+    });
+
+    it('should keep the full delay when random value is max', () => {
+      vi.spyOn(crypto, 'getRandomValues').mockImplementation((array) => {
+        if (array instanceof Uint32Array) {
+          array[0] = 0xffffffff;
+        }
+        return array;
+      });
+
+      expect(computeBackoffDelay('constant', 1, 1000, 30000, true)).toBe(1000);
+    });
+
+    it('should produce delays within the 0.5x-1x range', () => {
+      for (let i = 0; i < 20; i++) {
+        const delay = computeBackoffDelay('constant', 1, 1000, 30000, true);
+        expect(delay).toBeGreaterThanOrEqual(500);
+        expect(delay).toBeLessThanOrEqual(1000);
+      }
+    });
+
+    it('should never exceed maxDelay with jitter at the cap', () => {
+      for (let i = 0; i < 20; i++) {
+        const delay = computeBackoffDelay('exponential', 10, 1000, 5000, true);
+        expect(delay).toBeGreaterThanOrEqual(2500);
+        expect(delay).toBeLessThanOrEqual(5000);
+      }
+    });
+
+    it('should floor jittered delays to integers', () => {
+      const delay = computeBackoffDelay('constant', 1, 333, 30000, true);
+      expect(Number.isInteger(delay)).toBe(true);
+    });
+  });
+});

--- a/tests/integration/RequestRetryQueue.test.ts
+++ b/tests/integration/RequestRetryQueue.test.ts
@@ -140,6 +140,51 @@ describe('RequestInterceptor + RetryQueue', () => {
     queue.destroy();
   });
 
+  it('should honor Retry-After from a 429 via the retryAfterMs error hint', async () => {
+    fetchSpy
+      .mockResolvedValueOnce(
+        new Response('slow down', {
+          status: 429,
+          statusText: 'Too Many Requests',
+          headers: { 'Retry-After': '3' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response('ok', { status: 200, headers: { 'Content-Type': 'text/plain' } })
+      );
+
+    const interceptor = RequestInterceptor.create({
+      baseUrl: 'https://api.example.com',
+      allowedProtocols: ['https:'],
+      throwOnError: true,
+    });
+
+    const queue = RetryQueue.create({
+      maxRetries: 2,
+      backoff: 'constant',
+      baseDelay: 100,
+      jitter: false,
+    });
+
+    const resultPromise = queue.add(async () => {
+      const response = await interceptor.fetch('/rate-limited');
+      return response.text();
+    });
+
+    // The queue must wait the server-provided 3s, not its 100ms backoff
+    await vi.advanceTimersByTimeAsync(2900);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    const result = await resultPromise;
+    expect(result).toBe('ok');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    interceptor.destroy();
+    queue.destroy();
+  });
+
   it('should pass auth headers through interceptor within retried requests', async () => {
     fetchSpy.mockRejectedValueOnce(new TypeError('Network error')).mockResolvedValueOnce(
       new Response('authenticated', {

--- a/tests/network/RetryQueue.test.ts
+++ b/tests/network/RetryQueue.test.ts
@@ -1012,8 +1012,8 @@ describe('RetryQueue', () => {
 
         await vi.runAllTimersAsync();
 
-        // With jitter: delay * (0.5 + 0.5) = delay * 1.0 = 1000
-        expect(delays).toEqual([1000, 1000]);
+        // With equal jitter: delay * (0.5 + 0.5 * 0.5) = delay * 0.75 = 750
+        expect(delays).toEqual([750, 750]);
       });
 
       it('should produce delays in expected range with jitter', async () => {
@@ -1055,6 +1055,150 @@ describe('RetryQueue', () => {
 
         // With jitter and random=0: delay * 0.5 = 500
         expect(delays[0]).toBe(500);
+      });
+    });
+
+    describe('Retry-After hint', () => {
+      /**
+       * Collect retry delays passed to setTimeout.
+       */
+      function trackDelays(): number[] {
+        const delays: number[] = [];
+        const originalSetTimeout = globalThis.setTimeout;
+
+        vi.spyOn(globalThis, 'setTimeout').mockImplementation((fn, ms) => {
+          if (typeof ms === 'number' && ms > 0) {
+            delays.push(ms);
+          }
+          return originalSetTimeout(fn, ms) as unknown as ReturnType<typeof setTimeout>;
+        });
+
+        return delays;
+      }
+
+      it('should use retryAfterMs from the thrown error instead of backoff', async () => {
+        const delays = trackDelays();
+        const queue = RetryQueue.create({
+          maxRetries: 1,
+          baseDelay: 1000,
+          jitter: true,
+          networkAware: false,
+        });
+
+        let attempts = 0;
+        const promise = queue.add(async () => {
+          attempts++;
+          if (attempts === 1) {
+            throw Object.assign(new Error('Rate limited'), { retryAfterMs: 5000 });
+          }
+          return 'success';
+        });
+
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('success');
+        // Server-provided delay is used verbatim - no jitter applied
+        expect(delays).toEqual([5000]);
+      });
+
+      it('should cap retryAfterMs at maxDelay', async () => {
+        const delays = trackDelays();
+        const queue = RetryQueue.create({
+          maxRetries: 1,
+          baseDelay: 1000,
+          maxDelay: 30000,
+          jitter: false,
+          networkAware: false,
+        });
+
+        let attempts = 0;
+        const promise = queue.add(async () => {
+          attempts++;
+          if (attempts === 1) {
+            throw Object.assign(new Error('Rate limited'), { retryAfterMs: 90000 });
+          }
+          return 'success';
+        });
+
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('success');
+        expect(delays).toEqual([30000]);
+      });
+
+      it('should fall back to backoff for invalid retryAfterMs values', async () => {
+        const delays = trackDelays();
+        const queue = RetryQueue.create({
+          maxRetries: 4,
+          backoff: 'constant',
+          baseDelay: 1000,
+          jitter: false,
+          networkAware: false,
+        });
+
+        const invalidHints: unknown[] = [-1, Number.NaN, Number.POSITIVE_INFINITY, '5000'];
+        let attempts = 0;
+        const promise = queue.add(async () => {
+          const hint = invalidHints[attempts];
+          attempts++;
+          if (hint !== undefined) {
+            throw Object.assign(new Error('Fail'), { retryAfterMs: hint });
+          }
+          return 'success';
+        });
+
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('success');
+        expect(delays).toEqual([1000, 1000, 1000, 1000]);
+      });
+
+      it('should fall back to backoff for non-object errors', async () => {
+        const delays = trackDelays();
+        const queue = RetryQueue.create({
+          maxRetries: 1,
+          backoff: 'constant',
+          baseDelay: 1000,
+          jitter: false,
+          networkAware: false,
+        });
+
+        let attempts = 0;
+        const promise = queue.add(async () => {
+          attempts++;
+          if (attempts === 1) {
+            throw 'string error';
+          }
+          return 'success';
+        });
+
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('success');
+        expect(delays).toEqual([1000]);
+      });
+
+      it('should accept a zero retryAfterMs as immediate retry', async () => {
+        const queue = RetryQueue.create({
+          maxRetries: 1,
+          baseDelay: 60000,
+          jitter: false,
+          networkAware: false,
+        });
+
+        let attempts = 0;
+        const promise = queue.add(async () => {
+          attempts++;
+          if (attempts === 1) {
+            throw Object.assign(new Error('Retry now'), { retryAfterMs: 0 });
+          }
+          return 'success';
+        });
+
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toBe('success');
+        expect(attempts).toBe(2);
       });
     });
   });

--- a/tests/request/RequestInterceptor.test.ts
+++ b/tests/request/RequestInterceptor.test.ts
@@ -63,6 +63,13 @@ describe('RequestInterceptor', () => {
       const error = RequestError.responseError(404, 'Not Found');
       expect(error.code).toBe('RESPONSE_ERROR');
       expect(error.message).toBe('Response error: 404 Not Found');
+      expect(error.retryAfterMs).toBeUndefined();
+    });
+
+    it('should create RESPONSE_ERROR error with retryAfterMs', () => {
+      const error = RequestError.responseError(429, 'Too Many Requests', 5000);
+      expect(error.code).toBe('RESPONSE_ERROR');
+      expect(error.retryAfterMs).toBe(5000);
     });
 
     it('should create MIDDLEWARE_ERROR error', () => {
@@ -1219,6 +1226,48 @@ describe('RequestInterceptor', () => {
         await expect(api.fetch('/error')).rejects.toThrow();
 
         expect(onError).toHaveBeenCalled();
+
+        api.destroy();
+      });
+
+      it('should attach retryAfterMs when the error response has a Retry-After header', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('Too Many Requests', {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: { 'Retry-After': '4' },
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          throwOnError: true,
+        });
+
+        const error = await api.fetch('/limited').catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(RequestError);
+        expect((error as RequestError).code).toBe('RESPONSE_ERROR');
+        expect((error as RequestError).retryAfterMs).toBe(4000);
+
+        api.destroy();
+      });
+
+      it('should leave retryAfterMs undefined without a Retry-After header', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('Service Unavailable', {
+            status: 503,
+            statusText: 'Service Unavailable',
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          throwOnError: true,
+        });
+
+        const error = await api.fetch('/down').catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(RequestError);
+        expect((error as RequestError).retryAfterMs).toBeUndefined();
 
         api.destroy();
       });

--- a/tests/request/RequestRetry.test.ts
+++ b/tests/request/RequestRetry.test.ts
@@ -1,0 +1,629 @@
+/**
+ * RequestRetry Tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RequestInterceptor, RequestError } from '../../src/request/index.js';
+import {
+  resolveRetryConfig,
+  isReplayableBody,
+  isRetryableError,
+  computeRetryDelay,
+  waitRetryDelay,
+  discardResponseBody,
+} from '../../src/request/RequestRetry.js';
+
+const BASE_URL = 'https://api.example.com';
+
+describe('RequestRetry', () => {
+  describe('resolveRetryConfig', () => {
+    it('should apply defaults', () => {
+      const resolved = resolveRetryConfig({});
+
+      expect(resolved.maxRetries).toBe(3);
+      expect(resolved.backoff).toBe('exponential');
+      expect(resolved.baseDelay).toBe(1000);
+      expect(resolved.maxDelay).toBe(30000);
+      expect(resolved.jitter).toBe(true);
+      expect(resolved.methods).toEqual(['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+      expect(resolved.statusCodes).toEqual([408, 429, 500, 502, 503, 504]);
+    });
+
+    it('should keep explicit values', () => {
+      const resolved = resolveRetryConfig({
+        maxRetries: 1,
+        backoff: 'constant',
+        baseDelay: 50,
+        maxDelay: 100,
+        jitter: false,
+        methods: ['GET'],
+        statusCodes: [429],
+      });
+
+      expect(resolved.maxRetries).toBe(1);
+      expect(resolved.backoff).toBe('constant');
+      expect(resolved.baseDelay).toBe(50);
+      expect(resolved.maxDelay).toBe(100);
+      expect(resolved.jitter).toBe(false);
+      expect(resolved.methods).toEqual(['GET']);
+      expect(resolved.statusCodes).toEqual([429]);
+    });
+
+    it('should reject negative maxRetries', () => {
+      expect(() => resolveRetryConfig({ maxRetries: -1 })).toThrow(RequestError);
+    });
+
+    it('should reject non-integer maxRetries', () => {
+      expect(() => resolveRetryConfig({ maxRetries: 1.5 })).toThrow(RequestError);
+    });
+
+    it('should reject non-positive baseDelay', () => {
+      expect(() => resolveRetryConfig({ baseDelay: 0 })).toThrow(RequestError);
+    });
+
+    it('should reject non-positive maxDelay', () => {
+      expect(() => resolveRetryConfig({ maxDelay: 0 })).toThrow(RequestError);
+    });
+
+    it('should reject empty methods', () => {
+      expect(() => resolveRetryConfig({ methods: [] })).toThrow(RequestError);
+    });
+
+    it('should reject empty statusCodes', () => {
+      expect(() => resolveRetryConfig({ statusCodes: [] })).toThrow(RequestError);
+    });
+  });
+
+  describe('isReplayableBody', () => {
+    it('should accept absent bodies', () => {
+      expect(isReplayableBody(undefined)).toBe(true);
+      expect(isReplayableBody(null)).toBe(true);
+    });
+
+    it('should accept reusable body types', () => {
+      expect(isReplayableBody('{"a":1}')).toBe(true);
+      expect(isReplayableBody(new Blob(['data']))).toBe(true);
+      expect(isReplayableBody(new URLSearchParams({ a: '1' }))).toBe(true);
+    });
+
+    it('should reject ReadableStream bodies', () => {
+      expect(isReplayableBody(new ReadableStream())).toBe(false);
+    });
+  });
+
+  describe('isRetryableError', () => {
+    it('should retry network failures and timeouts', () => {
+      expect(isRetryableError(RequestError.requestFailed(BASE_URL))).toBe(true);
+      expect(isRetryableError(RequestError.timeout(BASE_URL, 1000))).toBe(true);
+    });
+
+    it('should not retry aborts or non-transient errors', () => {
+      expect(isRetryableError(RequestError.aborted(BASE_URL))).toBe(false);
+      expect(isRetryableError(RequestError.responseError(500, 'Server Error'))).toBe(false);
+      expect(isRetryableError(RequestError.invalidConfig('bad'))).toBe(false);
+    });
+  });
+
+  describe('computeRetryDelay', () => {
+    const config = resolveRetryConfig({ baseDelay: 1000, maxDelay: 5000, jitter: false });
+
+    it('should use the Retry-After header when present', () => {
+      expect(computeRetryDelay(config, 1, '2')).toBe(2000);
+    });
+
+    it('should cap the Retry-After delay at maxDelay', () => {
+      expect(computeRetryDelay(config, 1, '100')).toBe(5000);
+    });
+
+    it('should fall back to backoff for missing headers', () => {
+      expect(computeRetryDelay(config, 1, null)).toBe(1000);
+      expect(computeRetryDelay(config, 2, null)).toBe(2000);
+    });
+
+    it('should fall back to backoff for invalid headers', () => {
+      expect(computeRetryDelay(config, 1, 'soon')).toBe(1000);
+    });
+  });
+
+  describe('waitRetryDelay', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should resolve after the given delay', async () => {
+      let resolved = false;
+      void waitRetryDelay(1000, []).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(resolved).toBe(true);
+    });
+
+    it('should ignore undefined signals', async () => {
+      let resolved = false;
+      void waitRetryDelay(100, [undefined, undefined]).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(resolved).toBe(true);
+    });
+
+    it('should reject immediately for an already aborted signal', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(waitRetryDelay(1000, [controller.signal])).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+    });
+
+    it('should reject when a signal aborts during the wait', async () => {
+      const controller = new AbortController();
+      const promise = waitRetryDelay(1000, [undefined, controller.signal]);
+      const guarded = promise.catch((e: unknown) => e);
+
+      await vi.advanceTimersByTimeAsync(500);
+      controller.abort();
+
+      const error = await guarded;
+      expect(error).toBeInstanceOf(DOMException);
+      expect((error as DOMException).name).toBe('AbortError');
+    });
+  });
+
+  describe('discardResponseBody', () => {
+    it('should cancel the response body', async () => {
+      const cancel = vi.fn().mockResolvedValue(undefined);
+      const response = { body: { cancel } } as unknown as Response;
+
+      await discardResponseBody(response);
+
+      expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('should tolerate responses without a body', async () => {
+      const response = { body: null } as unknown as Response;
+
+      await expect(discardResponseBody(response)).resolves.toBeUndefined();
+    });
+
+    it('should ignore cancel failures', async () => {
+      const cancel = vi.fn().mockRejectedValue(new Error('locked'));
+      const response = { body: { cancel } } as unknown as Response;
+
+      await expect(discardResponseBody(response)).resolves.toBeUndefined();
+    });
+  });
+});
+
+describe('RequestInterceptor retry integration', () => {
+  let originalFetch: typeof fetch;
+  let mockFetch: ReturnType<typeof vi.fn<typeof fetch>>;
+
+  const respond = (status: number, headers?: Record<string, string>): Response =>
+    new Response(status === 204 ? null : '{"ok":true}', { status, headers });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    originalFetch = globalThis.fetch;
+    mockFetch = vi.fn<typeof fetch>();
+    globalThis.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('config validation', () => {
+    it('should reject invalid retry config at create time', () => {
+      expect(() => RequestInterceptor.create({ retry: { baseDelay: -1 } })).toThrow(RequestError);
+    });
+
+    it('should expose the retry config via getConfig', () => {
+      const api = RequestInterceptor.create({ retry: { maxRetries: 2 } });
+
+      expect(api.getConfig().retry).toEqual({ maxRetries: 2 });
+    });
+
+    it('should leave retry undefined in getConfig when not configured', () => {
+      const api = RequestInterceptor.create({});
+
+      expect(api.getConfig().retry).toBeUndefined();
+    });
+  });
+
+  describe('status-based retry', () => {
+    it('should retry a retryable status and return the successful response', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 3, baseDelay: 1000, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/data`);
+      await vi.advanceTimersByTimeAsync(1000);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry without retry config', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503));
+      const api = RequestInterceptor.create({});
+
+      const response = await api.get(`${BASE_URL}/data`);
+
+      expect(response.status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not retry non-retryable status codes', async () => {
+      mockFetch.mockResolvedValueOnce(respond(404));
+      const api = RequestInterceptor.create({ retry: { maxRetries: 3, jitter: false } });
+
+      const response = await api.get(`${BASE_URL}/missing`);
+
+      expect(response.status).toBe(404);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should honor a statusCodes override', async () => {
+      mockFetch.mockResolvedValueOnce(respond(418)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false, statusCodes: [418] },
+      });
+
+      const promise = api.get(`${BASE_URL}/teapot`);
+      await vi.advanceTimersByTimeAsync(100);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return the final response when retries are exhausted', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(respond(503)));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 2, baseDelay: 1000, backoff: 'exponential', jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/down`);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(2000);
+      const response = await promise;
+
+      expect(response.status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry with maxRetries 0', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503));
+      const api = RequestInterceptor.create({ retry: { maxRetries: 0 } });
+
+      const response = await api.get(`${BASE_URL}/data`);
+
+      expect(response.status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Retry-After header', () => {
+    it('should wait exactly the delta-seconds delay instead of backoff', async () => {
+      mockFetch
+        .mockResolvedValueOnce(respond(429, { 'Retry-After': '2' }))
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/limited`);
+
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should honor an HTTP-date Retry-After', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          respond(503, { 'Retry-After': new Date(Date.now() + 3000).toUTCString() })
+        )
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/maintenance`);
+
+      await vi.advanceTimersByTimeAsync(2999);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should cap the Retry-After delay at maxDelay', async () => {
+      mockFetch
+        .mockResolvedValueOnce(respond(429, { 'Retry-After': '100' }))
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, maxDelay: 5000, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/limited`);
+
+      await vi.advanceTimersByTimeAsync(4999);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should fall back to backoff for an invalid Retry-After', async () => {
+      mockFetch
+        .mockResolvedValueOnce(respond(503, { 'Retry-After': 'soon' }))
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 700, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/data`);
+      await vi.advanceTimersByTimeAsync(700);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('method eligibility', () => {
+    it('should not retry POST by default', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503));
+      const api = RequestInterceptor.create({ retry: { maxRetries: 3, jitter: false } });
+
+      const response = await api.post(`${BASE_URL}/submit`, '{"a":1}');
+
+      expect(response.status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry POST with an explicit methods override', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false, methods: ['GET', 'POST'] },
+      });
+
+      const promise = api.post(`${BASE_URL}/submit`, '{"a":1}');
+      await vi.advanceTimersByTimeAsync(100);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry PUT by default', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+
+      const promise = api.put(`${BASE_URL}/item`, '{"a":1}');
+      await vi.advanceTimersByTimeAsync(100);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('body eligibility', () => {
+    it('should not retry requests with a ReadableStream body', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503));
+      const api = RequestInterceptor.create({ retry: { maxRetries: 3, jitter: false } });
+
+      const response = await api.put(`${BASE_URL}/upload`, new ReadableStream());
+
+      expect(response.status).toBe(503);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('network errors', () => {
+    it('should retry network failures', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 1000, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/flaky`);
+      await vi.advanceTimersByTimeAsync(1000);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retry timeouts', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+        .mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 1000, jitter: false },
+      });
+
+      const promise = api.get(`${BASE_URL}/slow`);
+      await vi.advanceTimersByTimeAsync(1000);
+      const response = await promise;
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw after exhausting retries on persistent network failures', async () => {
+      mockFetch.mockImplementation(() => Promise.reject(new TypeError('Failed to fetch')));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 2, baseDelay: 1000, backoff: 'constant', jitter: false },
+      });
+
+      const guarded = api.get(`${BASE_URL}/dead`).catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(2000);
+      const error = await guarded;
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('REQUEST_FAILED');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry user aborts', async () => {
+      const controller = new AbortController();
+      mockFetch.mockImplementationOnce(() => {
+        controller.abort();
+        return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+      });
+      const api = RequestInterceptor.create({ retry: { maxRetries: 3, jitter: false } });
+
+      const guarded = api
+        .get(`${BASE_URL}/cancelled`, { signal: controller.signal })
+        .catch((e: unknown) => e);
+      const error = await guarded;
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('ABORTED');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should abort with ABORTED when the signal fires during the retry wait', async () => {
+      const controller = new AbortController();
+      mockFetch.mockResolvedValueOnce(respond(503));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 5000, jitter: false },
+      });
+
+      const guarded = api
+        .get(`${BASE_URL}/data`, { signal: controller.signal })
+        .catch((e: unknown) => e);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      controller.abort();
+
+      const error = await guarded;
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('ABORTED');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('interplay with throwOnError and middleware', () => {
+    it('should retry first and throw the final RESPONSE_ERROR with retryAfterMs', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(respond(429, { 'Retry-After': '7' })));
+      const api = RequestInterceptor.create({
+        throwOnError: true,
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+
+      const guarded = api.get(`${BASE_URL}/limited`).catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(7000);
+      const error = await guarded;
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('RESPONSE_ERROR');
+      expect((error as RequestError).retryAfterMs).toBe(7000);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should emit timing once for a retried request', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+      const timings: number[] = [];
+      api.onTiming((timing) => {
+        if (timing.status !== undefined) {
+          timings.push(timing.status);
+        }
+      });
+
+      const promise = api.get(`${BASE_URL}/data`);
+      await vi.advanceTimersByTimeAsync(100);
+      await promise;
+
+      expect(timings).toEqual([200]);
+    });
+
+    it('should run response middleware only for the final response', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+      const seen: number[] = [];
+      api.use({
+        onResponse: (response) => {
+          seen.push(response.status);
+          return response;
+        },
+      });
+
+      const promise = api.get(`${BASE_URL}/data`);
+      await vi.advanceTimersByTimeAsync(100);
+      await promise;
+
+      expect(seen).toEqual([200]);
+    });
+
+    it('should not retry when response middleware throws after a successful fetch', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(respond(200)));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 3, baseDelay: 100, jitter: false },
+      });
+      api.use({
+        onResponse: () => {
+          throw new Error('middleware exploded');
+        },
+      });
+
+      const error = await api.get(`${BASE_URL}/data`).catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('MIDDLEWARE_ERROR');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should run request middleware only once per call', async () => {
+      mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
+      const api = RequestInterceptor.create({
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+      const onRequest = vi.fn((config) => config);
+      api.use({ onRequest });
+
+      const promise = api.get(`${BASE_URL}/data`);
+      await vi.advanceTimersByTimeAsync(100);
+      await promise;
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/request/RetryAfter.test.ts
+++ b/tests/request/RetryAfter.test.ts
@@ -1,0 +1,67 @@
+/**
+ * RetryAfter Tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseRetryAfter } from '../../src/request/index.js';
+
+describe('parseRetryAfter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('delta-seconds format', () => {
+    it('should parse seconds into milliseconds', () => {
+      expect(parseRetryAfter('120')).toBe(120000);
+    });
+
+    it('should parse zero as immediate retry', () => {
+      expect(parseRetryAfter('0')).toBe(0);
+    });
+
+    it('should tolerate surrounding whitespace', () => {
+      expect(parseRetryAfter('  30  ')).toBe(30000);
+    });
+
+    it('should parse large values', () => {
+      expect(parseRetryAfter('86400')).toBe(86400000);
+    });
+  });
+
+  describe('HTTP-date format', () => {
+    it('should parse a future date as delay from now', () => {
+      expect(parseRetryAfter('Thu, 01 Jan 2026 00:00:03 GMT')).toBe(3000);
+    });
+
+    it('should clamp a past date to zero', () => {
+      expect(parseRetryAfter('Wed, 31 Dec 2025 23:59:00 GMT')).toBe(0);
+    });
+  });
+
+  describe('invalid values', () => {
+    it('should return null for null', () => {
+      expect(parseRetryAfter(null)).toBeNull();
+    });
+
+    it('should return null for empty and whitespace-only strings', () => {
+      expect(parseRetryAfter('')).toBeNull();
+      expect(parseRetryAfter('   ')).toBeNull();
+    });
+
+    it('should return null for non-integer numbers', () => {
+      expect(parseRetryAfter('1.5')).toBeNull();
+    });
+
+    it('should return null for negative numbers', () => {
+      expect(parseRetryAfter('-5')).toBeNull();
+    });
+
+    it('should return null for unparseable text', () => {
+      expect(parseRetryAfter('soon')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in automatic retry to `RequestInterceptor` — transient failures are retried with backoff, and server-provided `Retry-After` headers (429/503 etc.) override the computed delay. `RetryQueue` honors the same hint via a `retryAfterMs` field on thrown errors, so both retry layers compose out of the box. Closes #104.

## Changes

- **`parseRetryAfter(value)`** (new export): parses `Retry-After` per RFC 9110 — delta-seconds and HTTP-date; strict about garbage (`"1.5"`, `"-5"` → `null`), past dates → `0`.
- **`retry` config on `RequestInterceptor.create()`**: retries network errors, timeouts, and retryable status codes (default 408/429/500/502/503/504) with configurable backoff. Idempotent methods only by default — POST requires explicit opt-in; `ReadableStream` bodies are never replayed. A valid `Retry-After` replaces the computed delay (no jitter), capped at `maxDelay`. Request middleware runs once per logical request; response middleware and timing only see the final response; intermediate response bodies are cancelled.
- **`RequestError.retryAfterMs`**: set on `RESPONSE_ERROR` (with `throwOnError`) when the server sent the header.
- **`RetryQueue`**: any thrown error carrying a finite, non-negative `retryAfterMs` overrides the backoff for the next attempt, capped at `maxDelay`.
- **`computeBackoffDelay` / `BackoffStrategy`** extracted from `RetryQueue` into `core` (shared by both modules).
- **Equal jitter**: jitter now multiplies the capped delay by 0.5–1.0 (AWS equal-jitter scheme) instead of 0.5–1.5, making `maxDelay` a hard upper bound while keeping the spread at the cap intact.

## Design decisions (per library principles)

- **Opt-in retry, conservative defaults**: no retries without `retry` config; POST excluded by default (duplicate side effects), streams never replayed.
- **Loose coupling via duck-typed hint**: `RetryQueue` reads `retryAfterMs` off any error rather than importing from the request module, keeping module boundaries intact.
- **Server delay is authoritative but bounded**: `Retry-After` is never jittered and always capped at `maxDelay`, so a hostile/buggy server cannot park a client indefinitely.

## Quality

- [x] 4759 tests; new modules (`Backoff`, `RequestRetry`, `RetryAfter`) at 100% coverage
- [x] format, lint, typecheck, build, size (request: 4.46 kB < 4.5 kB) clean
- [x] Integration test: interceptor `throwOnError` + queue honoring a 429 `Retry-After`

## Reviews

- **Security review**: no findings — `Retry-After` is strictly parsed and clamped in both consumers; retries cannot bypass URL/credential-origin validation (config is validated once and fixed per request); aborted requests are never retried.
- **Follow-ups**: #184 (`AbortSignal.any()` refactor), #185 (double error-middleware on `throwOnError`, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeUph8xqbh4jRjhg9yvpPq