### PR TITLE
fix(request): run error middleware and timing once on throwOnError

### DIFF
--- a/src/request/RequestInterceptor.ts
+++ b/src/request/RequestInterceptor.ts
@@ -292,6 +292,7 @@ export interface RequestMiddleware {
 
 /**
  * Request timing information.
+ * Exactly one timing event is emitted per request.
  */
 export interface RequestTiming {
   readonly url: string;
@@ -299,7 +300,12 @@ export interface RequestTiming {
   readonly startTime: number;
   readonly endTime: number;
   readonly duration: number;
+  /** Response status; present when a response was received */
   readonly status?: number;
+  /**
+   * Error message; present when the request failed. A non-ok response with
+   * `throwOnError` carries both `status` and `error`.
+   */
   readonly error?: string;
 }
 
@@ -458,6 +464,17 @@ const DEFAULT_CONFIG: Required<
   expectedContentType: undefined,
   retry: undefined,
 } as const;
+
+/**
+ * Wrapper marking an error that has already been finalized (timing emitted,
+ * error middleware run). The retry loop unwraps and rethrows it as-is instead
+ * of sending it through the failure path a second time.
+ */
+class FinalizedRequestError extends Error {
+  constructor(readonly error: RequestError) {
+    super(error.message);
+  }
+}
 
 /**
  * Sensitive header names that should not be logged or leaked.
@@ -823,6 +840,33 @@ export const RequestInterceptor = {
           validateContentType(interceptedResponse.headers, config.expectedContentType);
         }
 
+        if (options.throwOnError && !response.ok) {
+          const error = RequestError.responseError(
+            response.status,
+            response.statusText,
+            parseRetryAfter(interceptedResponse.headers.get('Retry-After')) ?? undefined
+          );
+
+          // A response was received AND the request fails: one timing event
+          // carrying both the status and the error
+          emitTiming(
+            {
+              url: config.url,
+              method: config.method,
+              startTime,
+              endTime,
+              duration,
+              status: response.status,
+              error: error.message,
+            },
+            timingHandlers
+          );
+
+          await runErrorMiddleware(error, frozenConfig, middlewares);
+          // noinspection ExceptionCaughtLocallyJS
+          throw new FinalizedRequestError(error);
+        }
+
         emitTiming(
           {
             url: config.url,
@@ -834,17 +878,6 @@ export const RequestInterceptor = {
           },
           timingHandlers
         );
-
-        if (options.throwOnError && !response.ok) {
-          const error = RequestError.responseError(
-            response.status,
-            response.statusText,
-            parseRetryAfter(interceptedResponse.headers.get('Retry-After')) ?? undefined
-          );
-          await runErrorMiddleware(error, frozenConfig, middlewares);
-          // noinspection ExceptionCaughtLocallyJS
-          throw error;
-        }
 
         return interceptedResponse.response;
       };
@@ -874,6 +907,11 @@ export const RequestInterceptor = {
 
           return await finalize(response);
         } catch (e) {
+          if (e instanceof FinalizedRequestError) {
+            // Timing and error middleware already ran in finalize
+            throw e.error;
+          }
+
           const error = toRequestError(e, config.url, config.timeout ?? options.timeout, false);
 
           const delay = retryDelayForError(retry, attempt, error);

--- a/tests/request/RequestInterceptor.test.ts
+++ b/tests/request/RequestInterceptor.test.ts
@@ -1207,7 +1207,7 @@ describe('RequestInterceptor', () => {
         api.destroy();
       });
 
-      it('should call error middleware when throwing on error status', async () => {
+      it('should call error middleware exactly once when throwing on error status', async () => {
         mockFetch.mockResolvedValueOnce(
           new Response('Internal Server Error', {
             status: 500,
@@ -1225,7 +1225,36 @@ describe('RequestInterceptor', () => {
 
         await expect(api.fetch('/error')).rejects.toThrow();
 
-        expect(onError).toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
+
+        api.destroy();
+      });
+
+      it('should emit exactly one timing event with status and error', async () => {
+        mockFetch.mockResolvedValueOnce(
+          new Response('Internal Server Error', {
+            status: 500,
+            statusText: 'Internal Server Error',
+          })
+        );
+
+        const api = RequestInterceptor.create({
+          baseUrl: 'https://api.example.com',
+          throwOnError: true,
+        });
+
+        const timingHandler = vi.fn();
+        api.onTiming(timingHandler);
+
+        await expect(api.fetch('/error')).rejects.toThrow();
+
+        expect(timingHandler).toHaveBeenCalledTimes(1);
+        expect(timingHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            status: 500,
+            error: expect.stringContaining('500'),
+          })
+        );
 
         api.destroy();
       });

--- a/tests/request/RequestRetry.test.ts
+++ b/tests/request/RequestRetry.test.ts
@@ -554,6 +554,29 @@ describe('RequestInterceptor retry integration', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it('should run error middleware and timing once for an exhausted throwOnError request', async () => {
+      mockFetch.mockImplementation(() => Promise.resolve(respond(503)));
+      const api = RequestInterceptor.create({
+        throwOnError: true,
+        retry: { maxRetries: 1, baseDelay: 100, jitter: false },
+      });
+      const onError = vi.fn();
+      api.use({ onError });
+      const timingHandler = vi.fn();
+      api.onTiming(timingHandler);
+
+      const guarded = api.get(`${BASE_URL}/down`).catch((e: unknown) => e);
+      await vi.advanceTimersByTimeAsync(100);
+      const error = await guarded;
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(timingHandler).toHaveBeenCalledTimes(1);
+      expect(timingHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 503, error: expect.stringContaining('503') })
+      );
+    });
+
     it('should emit timing once for a retried request', async () => {
       mockFetch.mockResolvedValueOnce(respond(503)).mockResolvedValueOnce(respond(200));
       const api = RequestInterceptor.create({


### PR DESCRIPTION
## Summary

With `throwOnError: true`, a non-ok response previously ran error middleware twice and emitted two timing events — a success timing (with `status`) from finalization, then an error timing (with `error`) from the failure path. Error middleware and timing now run exactly once per request. Closes #185.

## Changes

- The `throwOnError` path emits a single timing event carrying both `status` and `error` (the response did arrive, and the request did fail — both are information), runs error middleware once, and throws an internal `FinalizedRequestError` marker.
- The retry loop's catch unwraps the marker and rethrows the inner `RequestError` as-is instead of sending it through the failure path again.
- `RequestTiming` TSDoc now states the contract explicitly: exactly one event per request; `status` = response received, `error` = request failed, both on `throwOnError`.

## Behavior change

Middleware authors who observed two `onError` calls per failed `throwOnError` request will now see one; timing handlers see one combined event instead of a success/error pair. `MIDDLEWARE_ERROR` and `CONTENT_TYPE_MISMATCH` paths were already single-run and are unchanged.

## Quality

- [x] Existing throwOnError middleware test tightened to `toHaveBeenCalledTimes(1)`
- [x] New tests: single combined timing event; retry-exhausted `throwOnError` runs middleware and timing once
- [x] format, lint, typecheck, build, coverage (request at 100%) clean

## Reviews

- **Security review**: no findings — timing handlers see strictly less data than before; the marker class is module-private and cannot be spoofed by middleware; all validation still runs before the throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeUph8xqbh4jRjhg9yvpPq