### PR TITLE
refactor(request): replace manual signal combination with AbortSignal.any()

### DIFF
--- a/documentation/request.md
+++ b/documentation/request.md
@@ -491,8 +491,9 @@ parseRetryAfter('garbage'); // null
 ## Combining Abort Signals
 
 Merge two `AbortSignal` instances into one. When either signal fires, the
-combined signal aborts and listeners on the other signal are cleaned up to
-prevent memory leaks.
+combined signal aborts with that signal's reason. A thin wrapper around
+`AbortSignal.any()` — the signal dependency is platform-managed, so combining
+does not accumulate listeners on long-lived source signals.
 
 ```typescript
 import { combineAbortSignals } from '@zappzarapp/browser-utils/request';

--- a/src/request/RequestInterceptor.ts
+++ b/src/request/RequestInterceptor.ts
@@ -706,18 +706,15 @@ export const RequestInterceptor = {
 
     /**
      * Convert error to RequestError.
+     * User/instance aborts are classified by signal state in performAttempt
+     * before this runs, so a remaining AbortError is a timeout.
      */
-    const toRequestError = (
-      e: unknown,
-      url: string,
-      timeout: number,
-      wasUserAborted: boolean
-    ): RequestError => {
+    const toRequestError = (e: unknown, url: string, timeout: number): RequestError => {
       if (e instanceof RequestError) {
         return e;
       }
       if (e instanceof DOMException && e.name === 'AbortError') {
-        return wasUserAborted ? RequestError.aborted(url) : RequestError.timeout(url, timeout);
+        return RequestError.timeout(url, timeout);
       }
       return RequestError.requestFailed(url, e);
     };
@@ -786,7 +783,7 @@ export const RequestInterceptor = {
       };
 
       // Combine long-lived signals (instance-level + user-provided) once per
-      // request, so retry attempts do not accumulate listeners on them
+      // request; the AbortSignal.any() dependency is platform-managed
       const baseSignal: AbortSignal = config.signal
         ? combineAbortSignals(config.signal, instanceSignal)
         : instanceSignal;
@@ -796,6 +793,7 @@ export const RequestInterceptor = {
       const performAttempt = async (): Promise<Response> => {
         const abortController = new AbortController();
         const timeoutId = createTimeout(config.timeout, abortController);
+        const timeoutMs = config.timeout ?? options.timeout;
 
         const signal = combineAbortSignals(baseSignal, abortController.signal);
 
@@ -813,8 +811,17 @@ export const RequestInterceptor = {
         } catch (e) {
           if (timeoutId !== null) clearTimeout(timeoutId);
 
-          const wasUserAborted = config.signal?.aborted === true || instanceSignal.aborted;
-          throw toRequestError(e, config.url, config.timeout ?? options.timeout, wasUserAborted);
+          // Classify aborts by signal state, not by the thrown value:
+          // AbortSignal.any() propagates custom abort reasons into fetch's
+          // rejection, which would otherwise be misread as a network failure
+          if (signal.aborted) {
+            const wasUserAborted = config.signal?.aborted === true || instanceSignal.aborted;
+            throw wasUserAborted
+              ? RequestError.aborted(config.url)
+              : RequestError.timeout(config.url, timeoutMs);
+          }
+
+          throw toRequestError(e, config.url, timeoutMs);
         }
       };
 
@@ -912,7 +919,7 @@ export const RequestInterceptor = {
             throw e.error;
           }
 
-          const error = toRequestError(e, config.url, config.timeout ?? options.timeout, false);
+          const error = toRequestError(e, config.url, config.timeout ?? options.timeout);
 
           const delay = retryDelayForError(retry, attempt, error);
           if (delay !== null) {

--- a/src/request/RequestRetry.ts
+++ b/src/request/RequestRetry.ts
@@ -221,35 +221,26 @@ export function waitRetryDelay(
   signals: readonly (AbortSignal | undefined)[]
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    const active = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+    const signal = AbortSignal.any(
+      signals.filter((candidate): candidate is AbortSignal => candidate !== undefined)
+    );
 
-    const abort = (): void => {
+    if (signal.aborted) {
       reject(new DOMException('Retry delay was aborted', 'AbortError'));
-    };
-
-    if (active.some((signal) => signal.aborted)) {
-      abort();
       return;
     }
 
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new DOMException('Retry delay was aborted', 'AbortError'));
+    };
+
     const timer = setTimeout(() => {
-      for (const signal of active) {
-        signal.removeEventListener('abort', onAbort);
-      }
+      signal.removeEventListener('abort', onAbort);
       resolve();
     }, ms);
 
-    const onAbort = (): void => {
-      clearTimeout(timer);
-      for (const signal of active) {
-        signal.removeEventListener('abort', onAbort);
-      }
-      abort();
-    };
-
-    for (const signal of active) {
-      signal.addEventListener('abort', onAbort, { once: true });
-    }
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/src/request/RequestValidation.ts
+++ b/src/request/RequestValidation.ts
@@ -193,31 +193,12 @@ export function validateCredentialOrigin(
 
 /**
  * Combine multiple AbortSignals into one.
- * When either signal fires, the combined signal aborts and
- * the listener on the other signal is removed to prevent leaks.
+ * Thin wrapper around `AbortSignal.any()`, kept as a stable public utility.
+ * The signal dependency is platform-managed, so combining does not
+ * accumulate listeners on long-lived source signals.
  */
 export function combineAbortSignals(signal1: AbortSignal, signal2: AbortSignal): AbortSignal {
-  const controller = new AbortController();
-
-  if (signal1.aborted || signal2.aborted) {
-    controller.abort();
-    return controller.signal;
-  }
-
-  const onAbort1 = (): void => {
-    controller.abort();
-    signal2.removeEventListener('abort', onAbort2);
-  };
-
-  const onAbort2 = (): void => {
-    controller.abort();
-    signal1.removeEventListener('abort', onAbort1);
-  };
-
-  signal1.addEventListener('abort', onAbort1, { once: true });
-  signal2.addEventListener('abort', onAbort2, { once: true });
-
-  return controller.signal;
+  return AbortSignal.any([signal1, signal2]);
 }
 
 /**

--- a/tests/request/RequestRetry.test.ts
+++ b/tests/request/RequestRetry.test.ts
@@ -514,6 +514,27 @@ describe('RequestInterceptor retry integration', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
+    it('should not retry aborts carrying a custom reason', async () => {
+      // AbortSignal.any() propagates custom abort reasons into fetch's
+      // rejection; classification must go by signal state, not error type
+      const controller = new AbortController();
+      const reason = new Error('user navigated away');
+      mockFetch.mockImplementationOnce(() => {
+        controller.abort(reason);
+        return Promise.reject(reason);
+      });
+      const api = RequestInterceptor.create({ retry: { maxRetries: 3, jitter: false } });
+
+      const guarded = api
+        .get(`${BASE_URL}/cancelled`, { signal: controller.signal })
+        .catch((e: unknown) => e);
+      const error = await guarded;
+
+      expect(error).toBeInstanceOf(RequestError);
+      expect((error as RequestError).code).toBe('ABORTED');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('should abort with ABORTED when the signal fires during the retry wait', async () => {
       const controller = new AbortController();
       mockFetch.mockResolvedValueOnce(respond(503));

--- a/tests/request/RequestValidation.test.ts
+++ b/tests/request/RequestValidation.test.ts
@@ -49,48 +49,29 @@ describe('combineAbortSignals', () => {
     expect(combined.aborted).toBe(true);
   });
 
-  it('should remove listener from signal2 when signal1 aborts', () => {
+  it('should delegate to AbortSignal.any so the platform manages the dependency', () => {
+    const anySpy = vi.spyOn(AbortSignal, 'any');
     const controller1 = new AbortController();
     const controller2 = new AbortController();
 
-    const removeSpy = vi.spyOn(controller2.signal, 'removeEventListener');
-
     combineAbortSignals(controller1.signal, controller2.signal);
 
-    controller1.abort();
+    expect(anySpy).toHaveBeenCalledWith([controller1.signal, controller2.signal]);
 
-    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
-
-    removeSpy.mockRestore();
+    anySpy.mockRestore();
   });
 
-  it('should remove listener from signal1 when signal2 aborts', () => {
+  it('should propagate the abort reason from the aborting signal', () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
 
-    const removeSpy = vi.spyOn(controller1.signal, 'removeEventListener');
+    const combined = combineAbortSignals(controller1.signal, controller2.signal);
 
-    combineAbortSignals(controller1.signal, controller2.signal);
+    const reason = new Error('stop it');
+    controller1.abort(reason);
 
-    controller2.abort();
-
-    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
-
-    removeSpy.mockRestore();
-  });
-
-  it('should not add listeners when signal1 is pre-aborted', () => {
-    const controller1 = new AbortController();
-    controller1.abort();
-    const controller2 = new AbortController();
-
-    const addSpy = vi.spyOn(controller2.signal, 'addEventListener');
-
-    combineAbortSignals(controller1.signal, controller2.signal);
-
-    expect(addSpy).not.toHaveBeenCalled();
-
-    addSpy.mockRestore();
+    expect(combined.aborted).toBe(true);
+    expect(combined.reason).toBe(reason);
   });
 });
 


### PR DESCRIPTION
## Summary

`combineAbortSignals` and `waitRetryDelay` managed abort listeners by hand and left them behind on long-lived signals (the instance-level abort signal) whenever a request completed without aborting — up to `maxRetries + 1` listeners per retried request since #186. Both now delegate to `AbortSignal.any()` (Baseline 2024), whose signal dependency is platform-managed. Closes #184.

## Changes

- **`combineAbortSignals`** is now a thin wrapper over `AbortSignal.any()` — signature and export unchanged (non-breaking, keeps #9 intact), so no consumer changes.
- **`waitRetryDelay`** combines its signals via `AbortSignal.any()`: one listener on the short-lived composite instead of manual bookkeeping across all sources.
- **Abort classification hardened**: `AbortSignal.any()` propagates custom abort reasons into fetch's rejection, so `controller.abort(new Error('…'))` would have been misread as a retryable `REQUEST_FAILED` instead of `ABORTED`. `performAttempt` now classifies by signal state, not thrown-value type; the dead `wasUserAborted` parameter of `toRequestError` is removed.

## Behavior notes

- Combined signals now abort with the source signal's reason (spec behavior) instead of a generic `AbortError`; `RequestError` classification is unaffected thanks to the state-based check.
- The listener-lifecycle improvement is engine-level and not observable in happy-dom (its `any()` polyfills via listeners) — the tests pin the delegation and the abort/reason behavior instead.

## Quality

- [x] White-box listener tests replaced with behavior tests (delegation, reason propagation); new regression test: custom-reason abort is not retried
- [x] format, lint, typecheck, build clean; request module at 100% coverage; net −18 lines

## Reviews

- **Security review**: no findings — no cancellation-bypass window, pre-aborted and empty-array edge cases behave identically, abort reasons flow only within the caller's own trust domain. The review surfaced the custom-reason classification regression, which this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeUph8xqbh4jRjhg9yvpPq