### PR TITLE
chore: migrate eslint-plugin-boundaries config to v7 syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,10 +55,10 @@ export default [
         },
       },
       'boundaries/elements': [
-        { type: 'entry', pattern: 'src/index.ts', mode: 'file' },
         { type: 'core', pattern: 'src/core' },
         { type: 'module', pattern: 'src/*', capture: ['family'] },
       ],
+      'boundaries/files': [{ pattern: 'src/index.ts', category: 'entry' }],
     },
     rules: {
       // TypeScript recommended rules
@@ -122,36 +122,43 @@ export default [
         'error',
         {
           default: 'disallow',
-          rules: [
+          policies: [
             // Entry point can import any module
             {
-              from: { type: 'entry' },
-              allow: [{ to: { type: 'core' } }, { to: { type: 'module' } }],
+              from: { file: { categories: 'entry' } },
+              allow: [
+                { to: { element: { type: 'core' } } },
+                { to: { element: { type: 'module' } } },
+              ],
             },
             // Core can only import from core (internal)
             {
-              from: { type: 'core' },
-              allow: [{ to: { type: 'core' } }],
+              from: { element: { type: 'core' } },
+              allow: [{ to: { element: { type: 'core' } } }],
             },
             // Domain modules can import from core and from themselves (same family)
             {
-              from: { type: 'module' },
+              from: { element: { type: 'module' } },
               allow: [
-                { to: { type: 'core' } },
-                { to: { type: 'module', captured: { family: '{{ from.captured.family }}' } } },
+                { to: { element: { type: 'core' } } },
+                {
+                  to: {
+                    element: { type: 'module', captured: { family: '{{ from.captured.family }}' } },
+                  },
+                },
               ],
             },
             // session extends BaseStorageManager from storage
             {
-              from: { type: 'module', captured: { family: 'session' } },
-              allow: [{ to: { type: 'module', captured: { family: 'storage' } } }],
+              from: { element: { type: 'module', captured: { family: 'session' } } },
+              allow: [{ to: { element: { type: 'module', captured: { family: 'storage' } } } }],
             },
             // offline integrates indexeddb persistence with network status
             {
-              from: { type: 'module', captured: { family: 'offline' } },
+              from: { element: { type: 'module', captured: { family: 'offline' } } },
               allow: [
-                { to: { type: 'module', captured: { family: 'indexeddb' } } },
-                { to: { type: 'module', captured: { family: 'network' } } },
+                { to: { element: { type: 'module', captured: { family: 'indexeddb' } } } },
+                { to: { element: { type: 'module', captured: { family: 'network' } } } },
               ],
             },
           ],


### PR DESCRIPTION
## Summary

Migrates `eslint.config.js` to the eslint-plugin-boundaries v7 syntax, silencing the deprecation warnings every lint run has printed since the v7 bump (#180): `rules` → `policies`, flat selectors wrapped in entity selectors (`{ element: … }`), and the entry file moved from the deprecated `mode: 'file'` element descriptor to a file descriptor (`boundaries/files`) with a `file: { categories: 'entry' }` policy selector.

## Quality

- [x] Lint runs clean with zero plugin warnings
- [x] Enforcement verified unchanged: a deliberate `core → form` import is still rejected; the entry point lints clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NeUph8xqbh4jRjhg9yvpPq